### PR TITLE
v0.2.0: Contains queries and range index improvements

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.3",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/coveragereport

--- a/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
+++ b/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
@@ -9,8 +9,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
 		<PackageReference Include="coverlet.collector" Version="3.1.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
+++ b/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
@@ -8,10 +8,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Akade.IndexedSet.Tests/Data/TestData.cs
+++ b/Akade.IndexedSet.Tests/Data/TestData.cs
@@ -1,3 +1,5 @@
 ﻿namespace Akade.IndexedSet.Tests.Data;
 
 public record TestData(int PrimaryKey, int IntProperty, Guid GuidProperty, string StringProperty);
+
+public record DenormalizedTestData(int PrimaryKey, IEnumerable<int> IntList);

--- a/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
+++ b/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
@@ -55,7 +55,7 @@ public class BinaryHeapTests
 
 
     [TestMethod]
-    public void querying_by_single_values_returns_correct_position_with_zero_length_when_emptyd()
+    public void querying_by_single_values_returns_correct_position_with_zero_length_when_empty()
     {
         Assert.AreEqual(0..0, _heap.GetRange(2));
     }

--- a/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
+++ b/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
@@ -68,4 +68,33 @@ public class BinaryHeapTests
         Assert.AreEqual(1..6, _heap.GetRange(2, 6));
         Assert.AreEqual(2..8, _heap.GetRange(4, 8));
     }
+
+    [TestMethod]
+    public void querying_multiple_values_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_elements()
+    {
+        //                     0  1  2  3  4  5  6  7  8  9  10
+        _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 5, 6, 6, 8, 9 });
+        // case 1:                               6  -  8
+        // case 1:                   2  -  -  -  -  -  8
+        // case 1:                               6  -  -  9
+        // case 1:                   2  -  -  -  -  -  -  9
+
+        Assert.AreEqual(6..9, _heap.GetRange(4, 8, inclusiveStart: false, inclusiveEnd: false));
+        Assert.AreEqual(2..9, _heap.GetRange(4, 8, inclusiveStart: true, inclusiveEnd: false));
+        Assert.AreEqual(6..10, _heap.GetRange(4, 8, inclusiveStart: false, inclusiveEnd: true));
+        Assert.AreEqual(2..10, _heap.GetRange(4, 8, inclusiveStart: true, inclusiveEnd: true));
+    }
+
+    [TestMethod]
+    public void querying_multiple_values_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_not_elements()
+    {
+        //                     0  1  2  3  4  5  6  7  8  9  10
+        _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 5, 6, 6, 8, 9 });
+        // all cases:                2  -  -  -  -  -  8
+
+        Assert.AreEqual(2..9, _heap.GetRange(3, 7, inclusiveStart: false, inclusiveEnd: false));
+        Assert.AreEqual(2..9, _heap.GetRange(3, 7, inclusiveStart: true, inclusiveEnd: false));
+        Assert.AreEqual(2..9, _heap.GetRange(3, 7, inclusiveStart: false, inclusiveEnd: true));
+        Assert.AreEqual(2..9, _heap.GetRange(3, 7, inclusiveStart: true, inclusiveEnd: true));
+    }
 }

--- a/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
+++ b/Akade.IndexedSet.Tests/DataStructures/BinaryHeapTests.cs
@@ -40,7 +40,7 @@ public class BinaryHeapTests
     }
 
     [TestMethod]
-    public void querying_single_values_returns_correct_ranges()
+    public void querying_by_single_values_returns_correct_ranges()
     {
         _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 6, 6, 8, 9 });
 
@@ -52,8 +52,38 @@ public class BinaryHeapTests
         Assert.AreEqual(9..10, _heap.GetRange(9));
     }
 
+
+
     [TestMethod]
-    public void querying_multiple_values_returns_correct_ranges()
+    public void querying_by_single_values_returns_correct_position_with_zero_length_when_emptyd()
+    {
+        Assert.AreEqual(0..0, _heap.GetRange(2));
+    }
+
+    [TestMethod]
+    public void querying_by_single_values_returns_correct_position_with_zero_length_when_no_matching_value_is_found()
+    {
+        _ = _heap.Add(5);
+        _ = _heap.Add(8);
+        Assert.AreEqual(1..1, _heap.GetRange(6));
+    }
+
+    [TestMethod]
+    public void querying_by_range_returns_empty_range_when_empty()
+    {
+        Assert.AreEqual(0..0, _heap.GetRange(3, 7, inclusiveStart: true, inclusiveEnd: true));
+    }
+
+    [TestMethod]
+    public void querying_by_range_values_returns_correct_position_with_zero_length_when_no_matching_value_is_found()
+    {
+        _ = _heap.Add(5);
+        _ = _heap.Add(8);
+        Assert.AreEqual(1..1, _heap.GetRange(6, 7));
+    }
+
+    [TestMethod]
+    public void querying_by_range_returns_correct_ranges()
     {
         //                     0  1  2  3  4  5  6  7  8  9
         _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 6, 6, 8, 9 });
@@ -70,7 +100,7 @@ public class BinaryHeapTests
     }
 
     [TestMethod]
-    public void querying_multiple_values_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_elements()
+    public void querying_by_range_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_elements()
     {
         //                     0  1  2  3  4  5  6  7  8  9  10
         _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 5, 6, 6, 8, 9 });
@@ -86,7 +116,7 @@ public class BinaryHeapTests
     }
 
     [TestMethod]
-    public void querying_multiple_values_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_not_elements()
+    public void querying_by_range_returns_correct_ranges_respecting_inclusive_or_exclusive_boundaries_when_boundaries_are_not_elements()
     {
         //                     0  1  2  3  4  5  6  7  8  9  10
         _heap.AddRange(new[] { 1, 2, 4, 4, 4, 4, 5, 6, 6, 8, 9 });

--- a/Akade.IndexedSet.Tests/MultiValueIndices.cs
+++ b/Akade.IndexedSet.Tests/MultiValueIndices.cs
@@ -1,5 +1,4 @@
 using Akade.IndexedSet.Tests.Data;
-using Akade.IndexedSet.Tests.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Akade.IndexedSet.Tests;
@@ -7,78 +6,38 @@ namespace Akade.IndexedSet.Tests;
 [TestClass]
 public class MultiValueIndices
 {
-    private IndexedSet<int, TestData> _indexedSet = null!;
-    private readonly TestData _a = new(0, 10, GuidGen.Get(1), "A");
-    private readonly TestData _b = new(1, 10, GuidGen.Get(2), "B");
-    private readonly TestData _c = new(2, 11, GuidGen.Get(3), "C");
-    private readonly TestData _d = new(3, 12, GuidGen.Get(4), "C");
-    private readonly TestData _e = new(4, 12, GuidGen.Get(4), "C");
+    private IndexedSet<int, DenormalizedTestData> _indexedSet = null!;
+    private readonly DenormalizedTestData _a = new(0, new[] { 1, 2, 3, 4 });
+    private readonly DenormalizedTestData _b = new(1, new[] { 2, 3 });
+    private readonly DenormalizedTestData _c = new(2, new[] { 3 });
+    private readonly DenormalizedTestData _d = new(3, new[] { 1, 2, 3 });
 
     [TestInitialize]
     public void Init()
     {
-        _indexedSet = IndexedSetBuilder<TestData>.Create(x => x.PrimaryKey)
-            .WithIndex(x => x.IntProperty)
-            .WithIndex(x => x.GuidProperty)
-            .WithIndex(x => x.StringProperty)
+        _indexedSet = IndexedSetBuilder<DenormalizedTestData>.Create(x => x.PrimaryKey)
+            .WithIndex(x => x.IntList)
             .Build();
 
         _indexedSet.Add(_a);
         _indexedSet.Add(_b);
         _indexedSet.Add(_c);
         _indexedSet.Add(_d);
-        _indexedSet.Add(_e);
     }
 
     [TestMethod]
-    public void retrieval_via_secondary_int_key_returns_correct_items()
+    public void contains_queries_return_correct_results()
     {
-        _indexedSet.AssertMultipleItems(x => x.IntProperty, expectedElements: new[] { _a, _b });
-        _indexedSet.AssertSingleItem(x => x.IntProperty, _c);
-        _indexedSet.AssertMultipleItems(x => x.IntProperty, expectedElements: new[] { _d, _e });
+        CollectionAssert.AreEquivalent(new[] { _a, _d }, _indexedSet.Where(x => x.IntList, contains: 1).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _a, _b, _d }, _indexedSet.Where(x => x.IntList, contains: 2).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _a, _b, _c, _d }, _indexedSet.Where(x => x.IntList, contains: 3).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _a }, _indexedSet.Where(x => x.IntList, contains: 4).ToArray());
     }
 
     [TestMethod]
-    public void retrieval_via_secondary_guid_key_returns_correct_items()
+    public void single_queries_return_correct_results()
     {
-        _indexedSet.AssertSingleItem(x => x.GuidProperty, _a);
-        _indexedSet.AssertSingleItem(x => x.GuidProperty, _b);
-        _indexedSet.AssertSingleItem(x => x.GuidProperty, _c);
-        _indexedSet.AssertMultipleItems(x => x.GuidProperty, expectedElements: new[] { _d, _e });
-    }
-
-    [TestMethod]
-    public void retrieval_via_secondary_string_key_returns_correct_items()
-    {
-        _indexedSet.AssertSingleItem(x => x.StringProperty, _a);
-        _indexedSet.AssertSingleItem(x => x.StringProperty, _b);
-        _indexedSet.AssertMultipleItems(x => x.StringProperty, expectedElements: new[] { _c, _d, _e });
-    }
-
-    [TestMethod]
-    [ExpectedException(typeof(NotSupportedException))]
-    public void range_queries_throw_exception()
-    {
-        _ = _indexedSet.Range(x => x.IntProperty, 5, 10).ToList();
-    }
-
-    [TestMethod]
-    public void retrieval_via_compound_key_returns_correct_items()
-    {
-        _indexedSet = new IndexedSetBuilder<int, TestData>(x => x.PrimaryKey)
-            .WithIndex(x => (x.IntProperty, x.StringProperty))
-            .Build();
-
-        _indexedSet.Add(_a);
-        _indexedSet.Add(_b);
-        _indexedSet.Add(_c);
-        _indexedSet.Add(_d);
-        _indexedSet.Add(_e);
-
-        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _a);
-        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _b);
-        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _c);
-        _indexedSet.AssertMultipleItems(x => (x.IntProperty, x.StringProperty), expectedElements: new[] { _d, _e });
+        Assert.AreEqual(_a, _indexedSet.Single(x => x.IntList, 4));
     }
 
     [TestMethod]

--- a/Akade.IndexedSet.Tests/MultiValueIndices.cs
+++ b/Akade.IndexedSet.Tests/MultiValueIndices.cs
@@ -81,5 +81,11 @@ public class MultiValueIndices
         _indexedSet.AssertMultipleItems(x => (x.IntProperty, x.StringProperty), expectedElements: new[] { _d, _e });
     }
 
-
+    [TestMethod]
+    public void Removal()
+    {
+        Assert.IsTrue(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Contains(0));
+    }
 }

--- a/Akade.IndexedSet.Tests/NonUniqueIndices.cs
+++ b/Akade.IndexedSet.Tests/NonUniqueIndices.cs
@@ -1,0 +1,91 @@
+using Akade.IndexedSet.Tests.Data;
+using Akade.IndexedSet.Tests.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Akade.IndexedSet.Tests;
+
+[TestClass]
+public class NonUniqueIndices
+{
+    private IndexedSet<int, TestData> _indexedSet = null!;
+    private readonly TestData _a = new(0, 10, GuidGen.Get(1), "A");
+    private readonly TestData _b = new(1, 10, GuidGen.Get(2), "B");
+    private readonly TestData _c = new(2, 11, GuidGen.Get(3), "C");
+    private readonly TestData _d = new(3, 12, GuidGen.Get(4), "C");
+    private readonly TestData _e = new(4, 12, GuidGen.Get(4), "C");
+
+    [TestInitialize]
+    public void Init()
+    {
+        _indexedSet = IndexedSetBuilder<TestData>.Create(x => x.PrimaryKey)
+            .WithIndex(x => x.IntProperty)
+            .WithIndex(x => x.GuidProperty)
+            .WithIndex(x => x.StringProperty)
+            .Build();
+
+        _indexedSet.Add(_a);
+        _indexedSet.Add(_b);
+        _indexedSet.Add(_c);
+        _indexedSet.Add(_d);
+        _indexedSet.Add(_e);
+    }
+
+    [TestMethod]
+    public void retrieval_via_secondary_int_key_returns_correct_items()
+    {
+        _indexedSet.AssertMultipleItems(x => x.IntProperty, expectedElements: new[] { _a, _b });
+        _indexedSet.AssertSingleItem(x => x.IntProperty, _c);
+        _indexedSet.AssertMultipleItems(x => x.IntProperty, expectedElements: new[] { _d, _e });
+    }
+
+    [TestMethod]
+    public void retrieval_via_secondary_guid_key_returns_correct_items()
+    {
+        _indexedSet.AssertSingleItem(x => x.GuidProperty, _a);
+        _indexedSet.AssertSingleItem(x => x.GuidProperty, _b);
+        _indexedSet.AssertSingleItem(x => x.GuidProperty, _c);
+        _indexedSet.AssertMultipleItems(x => x.GuidProperty, expectedElements: new[] { _d, _e });
+    }
+
+    [TestMethod]
+    public void retrieval_via_secondary_string_key_returns_correct_items()
+    {
+        _indexedSet.AssertSingleItem(x => x.StringProperty, _a);
+        _indexedSet.AssertSingleItem(x => x.StringProperty, _b);
+        _indexedSet.AssertMultipleItems(x => x.StringProperty, expectedElements: new[] { _c, _d, _e });
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void range_queries_throw_exception()
+    {
+        _ = _indexedSet.Range(x => x.IntProperty, 5, 10).ToList();
+    }
+
+    [TestMethod]
+    public void retrieval_via_compound_key_returns_correct_items()
+    {
+        _indexedSet = new IndexedSetBuilder<int, TestData>(x => x.PrimaryKey)
+            .WithIndex(x => (x.IntProperty, x.StringProperty))
+            .Build();
+
+        _indexedSet.Add(_a);
+        _indexedSet.Add(_b);
+        _indexedSet.Add(_c);
+        _indexedSet.Add(_d);
+        _indexedSet.Add(_e);
+
+        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _a);
+        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _b);
+        _indexedSet.AssertSingleItem(x => (x.IntProperty, x.StringProperty), _c);
+        _indexedSet.AssertMultipleItems(x => (x.IntProperty, x.StringProperty), expectedElements: new[] { _d, _e });
+    }
+
+    [TestMethod]
+    public void Removal()
+    {
+        Assert.IsTrue(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Contains(0));
+    }
+}

--- a/Akade.IndexedSet.Tests/RangeIndices.cs
+++ b/Akade.IndexedSet.Tests/RangeIndices.cs
@@ -112,5 +112,87 @@ public class RangeIndices
         _indexedSet.AssertMultipleItems(x => (x.IntProperty, x.StringProperty), expectedElements: new[] { _d, _e });
     }
 
+    [TestMethod]
+    public void min_and_max_return_correct_key_values()
+    {
+        Assert.AreEqual(10, _indexedSet.Min(x => x.IntProperty));
+        Assert.AreEqual(13, _indexedSet.Max(x => x.IntProperty));
 
+        Assert.AreEqual(GuidGen.Get(1), _indexedSet.Min(x => x.GuidProperty));
+        Assert.AreEqual(GuidGen.Get(5), _indexedSet.Max(x => x.GuidProperty));
+
+        Assert.AreEqual("B", _indexedSet.Min(x => x.StringProperty));
+        Assert.AreEqual("E", _indexedSet.Max(x => x.StringProperty));
+    }
+
+    [TestMethod]
+    public void minby_and_maxby_return_correct_elements()
+    {
+        CollectionAssert.AreEquivalent(new[] { _a, _b }, _indexedSet.MinBy(x => x.IntProperty).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _d, _e }, _indexedSet.MaxBy(x => x.IntProperty).ToArray());
+
+        CollectionAssert.AreEquivalent(new[] { _a }, _indexedSet.MinBy(x => x.GuidProperty).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _d, _e }, _indexedSet.MaxBy(x => x.GuidProperty).ToArray());
+
+        CollectionAssert.AreEquivalent(new[] { _a, }, _indexedSet.MinBy(x => x.StringProperty).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _c, _d, _e }, _indexedSet.MaxBy(x => x.StringProperty).ToArray());
+    }
+
+    [TestMethod]
+    public void LessThan_and_LessThanOrEquals_return_correct_elements()
+    {
+        CollectionAssert.AreEquivalent(new[] { _a, _b }, _indexedSet.LessThan(x => x.IntProperty, 11).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _a, _b, _c }, _indexedSet.LessThanOrEqual(x => x.IntProperty, 11).ToArray());
+    }
+
+    [TestMethod]
+    public void GreaterThan_and_GreaterThanOrEquals_return_correct_elements()
+    {
+        CollectionAssert.AreEquivalent(new[] { _d, _e }, _indexedSet.GreaterThan(x => x.IntProperty, 11).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _c, _d, _e }, _indexedSet.GreaterThanOrEqual(x => x.IntProperty, 11).ToArray());
+    }
+
+    [TestMethod]
+    public void Comparison_queries_return_empty_set_if_out_of_bounds()
+    {
+        Assert.IsFalse(_indexedSet.LessThan(x => x.IntProperty, 5).Any());
+        Assert.IsFalse(_indexedSet.LessThanOrEqual(x => x.IntProperty, 5).Any());
+
+        Assert.IsFalse(_indexedSet.GreaterThan(x => x.IntProperty, 20).Any());
+        Assert.IsFalse(_indexedSet.GreaterThanOrEqual(x => x.IntProperty, 20).Any());
+    }
+
+    [TestMethod]
+    public void All_queries_return_empty_enumerable_for_empty_set()
+    {
+        _indexedSet = new IndexedSetBuilder<int, TestData>(x => x.PrimaryKey)
+           .WithRangeIndex(x => x.IntProperty)
+           .Build();
+
+        Assert.IsFalse(_indexedSet.Where(x => x.IntProperty, 5).Any());
+        Assert.IsFalse(_indexedSet.Range(x => x.IntProperty, 5, 10).Any());
+
+        Assert.IsFalse(_indexedSet.LessThan(x => x.IntProperty, 5).Any());
+        Assert.IsFalse(_indexedSet.LessThanOrEqual(x => x.IntProperty, 5).Any());
+
+        Assert.IsFalse(_indexedSet.GreaterThan(x => x.IntProperty, 5).Any());
+        Assert.IsFalse(_indexedSet.GreaterThanOrEqual(x => x.IntProperty, 5).Any());
+
+        Assert.IsFalse(_indexedSet.MaxBy(x => x.IntProperty).Any());
+        Assert.IsFalse(_indexedSet.MinBy(x => x.IntProperty).Any());
+
+        Assert.IsFalse(_indexedSet.OrderBy(x => x.IntProperty).Any());
+        Assert.IsFalse(_indexedSet.OrderByDescending(x => x.IntProperty).Any());
+    }
+
+    [TestMethod]
+    public void Min_and_max_throws_for_empty_set()
+    {
+        _indexedSet = new IndexedSetBuilder<int, TestData>(x => x.PrimaryKey)
+           .WithRangeIndex(x => x.IntProperty)
+           .Build();
+
+        _ = Assert.ThrowsException<InvalidOperationException>(() => _indexedSet.Min(x => x.IntProperty));
+        _ = Assert.ThrowsException<InvalidOperationException>(() => _indexedSet.Max(x => x.IntProperty));
+    }
 }

--- a/Akade.IndexedSet.Tests/RangeIndices.cs
+++ b/Akade.IndexedSet.Tests/RangeIndices.cs
@@ -33,28 +33,37 @@ public class RangeIndices
     [TestMethod]
     public void range_query_on_ints_returns_correct_items()
     {
-        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 3, 25, expectedElements: new[] { _a, _b, _c, _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 8, 12, expectedElements: new[] { _a, _b, _c });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 11, 14, expectedElements: new[] { _c, _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 12, 14, expectedElements: new[] { _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 3, 25, inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 8, 12, inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 11, 14, inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 12, 14, inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _d, _e });
+    }
+
+    [TestMethod]
+    public void range_query_on_ints_correctly_respects_inclusive_or_exclusive_boundaries()
+    {
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 10, 13, inclusiveStart: false, inclusiveEnd: false, expectedElements: new[] { _c });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 10, 13, inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 10, 13, inclusiveStart: false, inclusiveEnd: true, expectedElements: new[] { _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.IntProperty, 10, 13, inclusiveStart: true, inclusiveEnd: true, expectedElements: new[] { _a, _b, _c, _d, _e });
     }
 
     [TestMethod]
     public void range_query_on_strings_returns_correct_items()
     {
-        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "A", "F", expectedElements: new[] { _a, _b, _c, _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "A", "D", expectedElements: new[] { _a, _b });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "D", "Z", expectedElements: new[] { _c, _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "E", "Z", expectedElements: new[] { _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "A", "F", inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "A", "D", inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "D", "Z", inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.StringProperty, "E", "Z", inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _c, _d, _e });
     }
 
     [TestMethod]
     public void range_query_on_guids_returns_correct_items()
     {
-        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(0), GuidGen.Get(12), expectedElements: new[] { _a, _b, _c, _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(0), GuidGen.Get(4), expectedElements: new[] { _a, _b, _c });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(4), GuidGen.Get(8), expectedElements: new[] { _d, _e });
-        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(5), GuidGen.Get(8), expectedElements: new[] { _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(0), GuidGen.Get(12), inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c, _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(0), GuidGen.Get(4), inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _a, _b, _c });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(4), GuidGen.Get(8), inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _d, _e });
+        _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(5), GuidGen.Get(8), inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _d, _e });
     }
 
 
@@ -84,13 +93,11 @@ public class RangeIndices
         _indexedSet.AssertMultipleItems(x => x.StringProperty, expectedElements: new[] { _c, _d, _e });
     }
 
-
-
     [TestMethod]
     public void retrieval_via_compound_key_returns_correct_items()
     {
         _indexedSet = new IndexedSetBuilder<int, TestData>(x => x.PrimaryKey)
-            .WithIndex(x => (x.IntProperty, x.StringProperty))
+            .WithRangeIndex(x => (x.IntProperty, x.StringProperty))
             .Build();
 
         _indexedSet.Add(_a);

--- a/Akade.IndexedSet.Tests/RangeIndices.cs
+++ b/Akade.IndexedSet.Tests/RangeIndices.cs
@@ -195,4 +195,12 @@ public class RangeIndices
         _ = Assert.ThrowsException<InvalidOperationException>(() => _indexedSet.Min(x => x.IntProperty));
         _ = Assert.ThrowsException<InvalidOperationException>(() => _indexedSet.Max(x => x.IntProperty));
     }
+
+    [TestMethod]
+    public void Removal()
+    {
+        Assert.IsTrue(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Contains(0));
+    }
 }

--- a/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Immutable;
+
+namespace Akade.IndexedSet.Tests.Samples.Graph;
+
+[TestClass]
+public class GraphSample
+{
+    [TestMethod]
+    public void efficiently_query_incoming_edges_on_nodes()
+    {
+        IndexedSet<int, Node> _graph = IndexedSetBuilder<Node>.Create(x => x.Id)
+                                                              .WithIndex<int>(x => x.ConnectedTo) // for special collections such as immutable arrays: make sure the correct overload has been selected by providing generic arguments
+                                                              .Build();
+
+        _graph.Add(new Node(id: 1, connectedTo: ImmutableArray.Create(2, 3, 4)));
+        _graph.Add(new Node(id: 2, connectedTo: ImmutableArray.Create(1, 2)));
+        _graph.Add(new Node(id: 3, connectedTo: ImmutableArray.Create(2, 4)));
+        _graph.Add(new Node(id: 4, connectedTo: ImmutableArray.Create(2, 3, 1)));
+
+        // fast variant via index
+        var fastResult = _graph.Where(x => x.ConnectedTo, 4)
+                               .Select(x => x.Id)
+                               .ToList();
+
+        // full enumeration via contains
+        var slowResult = _graph.FullScan()
+                               .Where(x => x.ConnectedTo.Contains(4))
+                               .Select(x => x.Id)
+                               .ToList();
+
+        CollectionAssert.AreEquivalent(new[] { 1, 3 }, fastResult);
+        CollectionAssert.AreEquivalent(new[] { 1, 3 }, slowResult);
+    }
+}

--- a/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
@@ -19,7 +19,7 @@ public class GraphSample
         _graph.Add(new Node(id: 4, connectedTo: ImmutableArray.Create(2, 3, 1)));
 
         // fast variant via index
-        var fastResult = _graph.Where(x => x.ConnectedTo, 4)
+        var fastResult = _graph.Where(x => x.ConnectedTo, contains: 4)
                                .Select(x => x.Id)
                                .ToList();
 

--- a/Akade.IndexedSet.Tests/Samples/Graph/Node.cs
+++ b/Akade.IndexedSet.Tests/Samples/Graph/Node.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Immutable;
+
+namespace Akade.IndexedSet.Tests.Samples.Graph;
+
+public class Node
+{
+    public Node(int id, ImmutableArray<int> connectedTo)
+    {
+        Id = id;
+        ConnectedTo = connectedTo;
+    }
+
+    public int Id { get; }
+    public ImmutableArray<int> ConnectedTo { get; }
+}

--- a/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardEntry.cs
+++ b/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardEntry.cs
@@ -1,0 +1,5 @@
+﻿namespace Akade.IndexedSet.Tests.Samples.Leaderboard;
+
+public record LeaderboardEntry(int Id, int Score, DateTimeOffset Timestamp)
+{
+}

--- a/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardSample.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Akade.IndexedSet.Tests.Samples.Leaderboard;
+
+[TestClass]
+public class LeaderboardSample
+{
+
+    private readonly IndexedSet<int, LeaderboardEntry> _leaderboard = IndexedSetBuilder<LeaderboardEntry>.Create(x => x.Id)
+        .WithRangeIndex(x => x.Score)
+        .WithRangeIndex(x => x.Timestamp)
+        .Build();
+    private readonly DateTimeOffset _now;
+
+    public LeaderboardSample()
+    {
+        _now = DateTimeOffset.UtcNow;
+
+        for (int i = 0; i <= 240; i++)
+        {
+            int daysInPast = i / 24;
+            int hour = i % 24;
+
+            _leaderboard.Add(new LeaderboardEntry(i, i * i, _now.AddDays(-daysInPast).AddHours(hour)));
+        }
+    }
+
+
+    [TestMethod]
+    public void get_overall_highscore()
+    {
+        Assert.AreEqual(240 * 240, _leaderboard.Max(x => x.Score));
+    }
+
+    [TestMethod]
+    public void get_top_ten()
+    {
+        var expected = Enumerable.Range(231, 10) // 231 to 240 (inclusive)
+                                 .Select(i => i * i)
+                                 .Take(10)
+                                 .Reverse()
+                                 .ToList();
+
+        var actual = _leaderboard.OrderByDescending(x => x.Score)
+                                 .Take(10)
+                                 .Select(x => x.Score)
+                                 .ToList();
+
+        CollectionAssert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void get_second_page_of_leaderboard()
+    {
+        var expected = Enumerable.Range(221, 10) // 221 to 230 (inclusive)
+                                 .Select(i => i * i)
+                                 .Take(10)
+                                 .Reverse()
+                                 .ToList();
+
+        var actual = _leaderboard.OrderByDescending(x => x.Score, skip: 10)
+                                 .Take(10)
+                                 .Select(x => x.Score)
+                                 .ToList();
+
+        CollectionAssert.AreEqual(expected, actual);
+    }
+}

--- a/Akade.IndexedSet.Tests/UniqueIndices.cs
+++ b/Akade.IndexedSet.Tests/UniqueIndices.cs
@@ -79,4 +79,12 @@ public class UniqueIndices
     {
         _indexedSet.Add(new TestData(5, 10, Guid.NewGuid(), "ew"));
     }
+
+    [TestMethod]
+    public void Removal()
+    {
+        Assert.IsTrue(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Remove(0));
+        Assert.IsFalse(_indexedSet.Contains(0));
+    }
 }

--- a/Akade.IndexedSet.Tests/Utilities/IndexAssert.cs
+++ b/Akade.IndexedSet.Tests/Utilities/IndexAssert.cs
@@ -53,13 +53,21 @@ internal static class IndexAssert
         }
     }
 
-    public static void AssertMultipleItemsViaRange<TPrimaryKey, TElement, TIndexKey>(this IndexedSet<TPrimaryKey, TElement> indexedSet, Func<TElement, TIndexKey> indexAccessor, TIndexKey inclusiveStart, TIndexKey exclusiveEnd, [CallerArgumentExpression("indexAccessor")] string? indexName = null, params TElement[] expectedElements)
+    public static void AssertMultipleItemsViaRange<TPrimaryKey, TElement, TIndexKey>
+        (this IndexedSet<TPrimaryKey, TElement> indexedSet,
+        Func<TElement, TIndexKey> indexAccessor, 
+        TIndexKey start,
+        TIndexKey end, 
+        bool inclusiveStart,
+        bool inclusiveEnd,
+        [CallerArgumentExpression("indexAccessor")] string? indexName = null,
+        params TElement[] expectedElements)
         where TPrimaryKey : notnull
         where TIndexKey : notnull
     {
         Assert.IsNotNull(indexName);
 
-        IEnumerable<TElement> actualElements = indexedSet.Range(indexAccessor, inclusiveStart, exclusiveEnd, indexName);
+        IEnumerable<TElement> actualElements = indexedSet.Range(indexAccessor, start, end, inclusiveStart, inclusiveEnd, indexName);
 
         CollectionAssert.AreEqual(expectedElements.Select(indexAccessor).ToArray(), actualElements.Select(indexAccessor).ToArray());
         CollectionAssert.AreEquivalent(expectedElements, actualElements.ToArray());

--- a/Akade.IndexedSet.Tests/Utilities/IndexAssert.cs
+++ b/Akade.IndexedSet.Tests/Utilities/IndexAssert.cs
@@ -55,9 +55,9 @@ internal static class IndexAssert
 
     public static void AssertMultipleItemsViaRange<TPrimaryKey, TElement, TIndexKey>
         (this IndexedSet<TPrimaryKey, TElement> indexedSet,
-        Func<TElement, TIndexKey> indexAccessor, 
+        Func<TElement, TIndexKey> indexAccessor,
         TIndexKey start,
-        TIndexKey end, 
+        TIndexKey end,
         bool inclusiveStart,
         bool inclusiveEnd,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null,

--- a/Akade.IndexedSet.sln
+++ b/Akade.IndexedSet.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\ci-build.yml = .github\workflows\ci-build.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\publish-to-nuget-org.yml = .github\workflows\publish-to-nuget-org.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akade.IndexedSet.Tests", "Akade.IndexedSet.Tests\Akade.IndexedSet.Tests.csproj", "{E504884A-2704-4030-8B12-74FD40F7534C}"

--- a/Akade.IndexedSet/Akade.IndexedSet.csproj
+++ b/Akade.IndexedSet/Akade.IndexedSet.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<Version>0.1.1</Version>
+		<Version>0.2.0</Version>
 		<VersionSuffix>beta</VersionSuffix>
 		<Description>Provides an In-Memory data structure, the IndexedSet, that allows to easily add indices to allow efficient querying. Currently supports unique and non-unique indices as well as range indices for single attribute, compound or computed keys.</Description>
 		<Copyright>Copyright © Akade 2022</Copyright>

--- a/Akade.IndexedSet/DataStructures/BinaryHeap.cs
+++ b/Akade.IndexedSet/DataStructures/BinaryHeap.cs
@@ -75,38 +75,40 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
             start = ~start;
         }
         int actualStart = GetFirstIndexWithValue(value, start);
-        int end = GetLastIndexWithValue(value, start);
+        int end = GetFirstIndexWithDifferentValue(value, start);
 
-        return new Range(actualStart, end + 1);
+        return new Range(actualStart, end);
     }
 
-    public Range GetRange(TValue inclusiveStart, TValue exclusiveEnd)
+    public Range GetRange(TValue start, TValue end, bool inclusiveStart = true, bool inclusiveEnd = false)
     {
-        if (_comparer.Compare(inclusiveStart, exclusiveEnd) >= 0)
+        if (_comparer.Compare(start, end) >= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(exclusiveEnd));
+            throw new ArgumentOutOfRangeException(nameof(end));
         }
 
-        int start = _data.BinarySearch(inclusiveStart, _comparer);
-        if (start < 0)
+        int startIndex = _data.BinarySearch(start, _comparer);
+        if (startIndex < 0)
         {
-            start = ~start;
+            startIndex = ~startIndex;
         }
 
-        start = GetFirstIndexWithValue(inclusiveStart, start);
+        startIndex = inclusiveStart ? GetFirstIndexWithValue(start, startIndex) : GetFirstIndexWithDifferentValue(start, startIndex);
 
-        int end = _data.BinarySearch(start, _data.Count - start, exclusiveEnd, _comparer);
-        if (end < 0)
+
+        int endIndex = _data.BinarySearch(startIndex, _data.Count - startIndex, end, _comparer);
+        
+        if (endIndex < 0)
         {
-            end = ~end;
+            endIndex = ~endIndex;
         }
 
-        if (end < _data.Count)
+        if (endIndex < _data.Count)
         {
-            end = GetFirstIndexWithValue(exclusiveEnd, end);
+            endIndex = inclusiveEnd ? GetFirstIndexWithDifferentValue(end, endIndex) : GetFirstIndexWithValue(end, endIndex);
         }
 
-        return new Range(start, end);
+        return new Range(startIndex, endIndex);
     }
 
     private int GetFirstIndexWithValue(TValue value, int start)
@@ -124,7 +126,7 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
         return start + 1;
     }
 
-    private int GetLastIndexWithValue(TValue value, int start)
+    private int GetFirstIndexWithDifferentValue(TValue value, int start)
     {
         if (_comparer.Compare(_data[start], value) != 0)
         {
@@ -136,7 +138,7 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
             start++;
         }
 
-        return start - 1;
+        return start;
     }
 
     void ICollection<TValue>.Add(TValue item)

--- a/Akade.IndexedSet/DataStructures/BinaryHeap.cs
+++ b/Akade.IndexedSet/DataStructures/BinaryHeap.cs
@@ -69,11 +69,17 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
 
     public Range GetRange(TValue value)
     {
+        if (_data.Count == 0)
+        {
+            return 0..0;
+        }
+
         int start = _data.BinarySearch(value, _comparer);
         if (start < 0)
         {
             start = ~start;
         }
+
         int actualStart = GetFirstIndexWithValue(value, start);
         int end = GetFirstIndexWithDifferentValue(value, start);
 
@@ -87,6 +93,11 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
             throw new ArgumentOutOfRangeException(nameof(end));
         }
 
+        if (_data.Count == 0)
+        {
+            return 0..0;
+        }
+
         int startIndex = _data.BinarySearch(start, _comparer);
         if (startIndex < 0)
         {
@@ -97,7 +108,7 @@ internal class BinaryHeap<TValue> : ICollection<TValue>
 
 
         int endIndex = _data.BinarySearch(startIndex, _data.Count - startIndex, end, _comparer);
-        
+
         if (endIndex < 0)
         {
             endIndex = ~endIndex;

--- a/Akade.IndexedSet/DataStructures/SortedLookup.cs
+++ b/Akade.IndexedSet/DataStructures/SortedLookup.cs
@@ -59,13 +59,61 @@ internal class SortedLookup<TKey, TValue>
         return GetValues(range);
     }
 
-    private IEnumerable<TValue> GetValues(Range range)
+    public IEnumerable<TValue> GetValues(Range range)
     {
         (int offset, int length) = range.GetOffsetAndLength(_sortedKeys.Count);
 
         for (int i = 0; i < length; i++)
         {
             yield return _sortedValues[i + offset];
+        }
+    }
+
+    public IEnumerable<TValue> GetMaximumValues()
+    {
+        if (_sortedKeys.Count == 0)
+        {
+            return Enumerable.Empty<TValue>();
+        }
+
+        Range maximumRange = _sortedKeys.GetRange(GetMaximumKey());
+        return GetValues(maximumRange);
+    }
+
+    public IEnumerable<TValue> GetMinimumValues()
+    {
+        if (_sortedKeys.Count == 0)
+        {
+            return Enumerable.Empty<TValue>();
+        }
+
+        Range maximumRange = _sortedKeys.GetRange(GetMinimumKey());
+        return GetValues(maximumRange);
+    }
+
+    public TKey GetMaximumKey()
+    {
+        return _sortedKeys.Count == 0
+            ? throw new InvalidOperationException("Cannot retrieve the maximum value when the set is empty.")
+            : _sortedKeys[^1];
+    }
+
+    public TKey GetMinimumKey()
+    {
+        return _sortedKeys.Count == 0
+           ? throw new InvalidOperationException("Cannot retrieve the minimum value when the set is empty.")
+           : _sortedKeys[0];
+    }
+
+    public int Count => _sortedKeys.Count;
+
+    public IEnumerable<TValue> GetValuesDescending(Range range)
+    {
+        (int offset, int length) = range.GetOffsetAndLength(_sortedKeys.Count);
+
+        for (int i = 1; i <= length; i++)
+        {
+            yield return _sortedValues[_sortedValues.Count - offset - i];
         }
     }
 }

--- a/Akade.IndexedSet/DataStructures/SortedLookup.cs
+++ b/Akade.IndexedSet/DataStructures/SortedLookup.cs
@@ -53,9 +53,9 @@ internal class SortedLookup<TKey, TValue>
 
     }
 
-    public IEnumerable<TValue> GetValuesInRange(TKey inclusiveStart, TKey exclusiveEnd)
+    public IEnumerable<TValue> GetValuesInRange(TKey start, TKey end, bool inclusiveStart, bool inclusiveEnd)
     {
-        Range range = _sortedKeys.GetRange(inclusiveStart, exclusiveEnd);
+        Range range = _sortedKeys.GetRange(start, end, inclusiveStart, inclusiveEnd);
         return GetValues(range);
     }
 

--- a/Akade.IndexedSet/IndexedSet.cs
+++ b/Akade.IndexedSet/IndexedSet.cs
@@ -109,25 +109,80 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     }
 
     /// <summary>
-    /// Searches for multiple elements that are within a range via an index.
+    /// Searches for multiple elements via an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexKey">The key within the index.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> Where<TIndexKey>(
+        Func<TElement, IEnumerable<TIndexKey>> indexAccessor,
+        TIndexKey indexKey,
+        [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.Where(indexKey);
+    }
+
+    /// <summary>
+    /// Searches for multiple elements that are within a range via an index. You can specify whether the start/end are inclusive or exclusive
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
     /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. 
     /// Hence, the convention is to always use x as an identifier in case a lambda expression is used. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
-    /// <param name="inclusiveStart">The inclusive start "key" </param>
-    /// <param name="exclusiveEnd">The key within the index.</param>
+    /// <param name="start">The start "key", use <paramref name="inclusiveStart"/> to control whether the result should include the start or not </param>
+    /// <param name="end">The end "key", use <paramref name="inclusiveEnd"/> to control whether the result should include the end or not </param>
+    /// <param name="inclusiveStart">True, if the query should include the start, otherwise false.</param>
+    /// <param name="inclusiveEnd">True, if the query should include the end, otherwise false.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> Range<TIndexKey>(
         Func<TElement, TIndexKey> indexAccessor,
-        TIndexKey inclusiveStart,
-        TIndexKey exclusiveEnd,
+        TIndexKey start,
+        TIndexKey end,
+        bool inclusiveStart = true,
+        bool inclusiveEnd = false,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
     {
         TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
-        return typedIndex.Range(inclusiveStart, exclusiveEnd);
+        return typedIndex.Range(start, end, inclusiveStart, inclusiveEnd);
+    }
+
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> LessThan<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.LessThan(value);
+    }
+
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> LessThanOrEqual<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.LessThanOrEqual(value);
+    }
+
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> GreaterThan<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.GreaterThan(value);
+    }
+
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> GreaterThanOrEqual<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.GreaterThanOrEqual(value);
     }
 
     /// <summary>

--- a/Akade.IndexedSet/IndexedSet.cs
+++ b/Akade.IndexedSet/IndexedSet.cs
@@ -74,7 +74,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for an element via an index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexKey">The key within the index.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -90,10 +90,29 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     }
 
     /// <summary>
+    /// Searches for an element via an index  within "denormalized keys". See <see cref="IndexedSetBuilder{TPrimaryKey, TElement}.WithIndex{TIndexKey}(Func{TElement, IEnumerable{TIndexKey}}, string?)"/>.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="contains">The key within the index. The convention is to write the parameter name for increased readability i.e. .Single(x => x.Prop, contains: value).</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public TElement Single<TIndexKey>(
+        Func<TElement, IEnumerable<TIndexKey>> indexAccessor,
+        TIndexKey contains,
+        [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.Single(contains);
+    }
+
+    /// <summary>
     /// Searches for multiple elements via an index. See <see cref="IndexedSetBuilder{TPrimaryKey, TElement}.WithIndex{TIndexKey}(Func{TElement, TIndexKey}, string?)"/>.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexKey">The key within the index.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -112,19 +131,19 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for multiple elements via an index within "denormalized keys". See <see cref="IndexedSetBuilder{TPrimaryKey, TElement}.WithIndex{TIndexKey}(Func{TElement, IEnumerable{TIndexKey}}, string?)"/>.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
-    /// <param name="indexKey">The key within the index.</param>
+    /// <param name="contains">The key within the index. The convention is to write the parameter name for increased readability i.e. .Where(x => x.Prop, contains: value).</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> Where<TIndexKey>(
         Func<TElement, IEnumerable<TIndexKey>> indexAccessor,
-        TIndexKey indexKey,
+        TIndexKey contains,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
     {
         TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
-        return typedIndex.Where(indexKey);
+        return typedIndex.Where(contains);
     }
 
     /// <summary>
@@ -157,7 +176,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have keys that are less than the supplied value.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="value">The key value to compare other keys with.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -173,7 +192,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have keys that are less or equal than the supplied value.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="value">The key value to compare other keys with.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -189,7 +208,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have keys that are greator than the supplied value.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="value">The key value to compare other keys with.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -205,7 +224,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have keys that are greator or equal than the supplied value.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="value">The key value to compare other keys with.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -221,7 +240,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for the maximum key value within an index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
@@ -236,7 +255,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for the minimum key value within an index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
@@ -251,7 +270,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have the maximum key value within an index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
@@ -266,7 +285,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Searches for elements that have the minimum key value within an index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
@@ -281,7 +300,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// Returns the elements in the order defined by the index.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="skip">Allows to efficiently skip a number of elements. Default is 0</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
@@ -298,7 +317,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
     /// <param name="skip">Allows to efficiently skip a number of elements. Default is 0</param>
-    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]

--- a/Akade.IndexedSet/IndexedSet.cs
+++ b/Akade.IndexedSet/IndexedSet.cs
@@ -90,7 +90,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     }
 
     /// <summary>
-    /// Searches for multiple elements via an index.
+    /// Searches for multiple elements via an index. See <see cref="IndexedSetBuilder{TPrimaryKey, TElement}.WithIndex{TIndexKey}(Func{TElement, TIndexKey}, string?)"/>.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
     /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
@@ -109,7 +109,7 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
     }
 
     /// <summary>
-    /// Searches for multiple elements via an index.
+    /// Searches for multiple elements via an index within "denormalized keys". See <see cref="IndexedSetBuilder{TPrimaryKey, TElement}.WithIndex{TIndexKey}(Func{TElement, IEnumerable{TIndexKey}}, string?)"/>.
     /// </summary>
     /// <typeparam name="TIndexKey">The type of the index key</typeparam>
     /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
@@ -153,6 +153,14 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
         return typedIndex.Range(start, end, inclusiveStart, inclusiveEnd);
     }
 
+    /// <summary>
+    /// Searches for elements that have keys that are less than the supplied value.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="value">The key value to compare other keys with.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> LessThan<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
@@ -161,6 +169,14 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
         return typedIndex.LessThan(value);
     }
 
+    /// <summary>
+    /// Searches for elements that have keys that are less or equal than the supplied value.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="value">The key value to compare other keys with.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> LessThanOrEqual<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
@@ -169,6 +185,14 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
         return typedIndex.LessThanOrEqual(value);
     }
 
+    /// <summary>
+    /// Searches for elements that have keys that are greator than the supplied value.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="value">The key value to compare other keys with.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> GreaterThan<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
@@ -177,12 +201,112 @@ public class IndexedSet<TPrimaryKey, TElement> where TPrimaryKey : notnull
         return typedIndex.GreaterThan(value);
     }
 
+    /// <summary>
+    /// Searches for elements that have keys that are greator or equal than the supplied value.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="value">The key value to compare other keys with.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
     public IEnumerable<TElement> GreaterThanOrEqual<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, TIndexKey value, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
         where TIndexKey : notnull
     {
         TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
         return typedIndex.GreaterThanOrEqual(value);
+    }
+
+    /// <summary>
+    /// Searches for the maximum key value within an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public TIndexKey Max<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.Max();
+    }
+
+    /// <summary>
+    /// Searches for the minimum key value within an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public TIndexKey Min<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.Min();
+    }
+
+    /// <summary>
+    /// Searches for elements that have the maximum key value within an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> MaxBy<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.MaxBy();
+    }
+
+    /// <summary>
+    /// Searches for elements that have the minimum key value within an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> MinBy<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.MinBy();
+    }
+
+    /// <summary>
+    /// Returns the elements in the order defined by the index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="skip">Allows to efficiently skip a number of elements. Default is 0</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> OrderBy<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, int skip = 0, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.OrderBy(skip);
+    }
+
+    /// <summary>
+    /// Returns the elements in the descending order defined by the index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="skip">Allows to efficiently skip a number of elements. Default is 0</param>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identiefer. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
+    public IEnumerable<TElement> OrderByDescending<TIndexKey>(Func<TElement, TIndexKey> indexAccessor, int skip = 0, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TPrimaryKey, TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.OrderByDescending(skip);
     }
 
     /// <summary>

--- a/Akade.IndexedSet/IndexedSetBuilder.cs
+++ b/Akade.IndexedSet/IndexedSetBuilder.cs
@@ -78,6 +78,31 @@ public class IndexedSetBuilder<TPrimaryKey, TElement> where TPrimaryKey : notnul
             throw new ArgumentNullException(nameof(indexName));
         }
 
+        _result.AddIndex(new NonUniqueIndex<TPrimaryKey, TElement, TIndexKey>(keyAccessor, indexName));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="IndexedSet{TPrimaryKey, TElement}"/> to have a nonunique index based on a secondary key.
+    /// The secondary key can be any expression that does not change while the element is within the indexed set, even
+    /// tuples or calculated expressions. The name of the index is based on the string representation of the expression
+    /// and passed by the compiler to <paramref name="indexName"/>. The convention is to always use x as a lambda parameter:
+    /// x => (x.Prop1, x.Prop2, x.Prop3). Alternativly, you can also always use the same method from a static class.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the key within the index</typeparam>
+    /// <param name="keyAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. 
+    /// Hence, the convention is to always use x as an identifier in case a lambda expression is used.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="keyAccessor"/> is automatically passed by the compiler.</param>
+    /// <returns>The instance on which this method is called is returned to support the fluent syntax.</returns>
+    public IndexedSetBuilder<TPrimaryKey, TElement> WithIndex<TIndexKey>(Func<TElement, IEnumerable<TIndexKey>> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        if (indexName is null)
+        {
+            throw new ArgumentNullException(nameof(indexName));
+        }
+
         _result.AddIndex(new MultiValueIndex<TPrimaryKey, TElement, TIndexKey>(keyAccessor, indexName));
 
         return this;

--- a/Akade.IndexedSet/Indices/NonUniqueIndex.cs
+++ b/Akade.IndexedSet/Indices/NonUniqueIndex.cs
@@ -1,0 +1,39 @@
+﻿namespace Akade.IndexedSet.Indices;
+
+/// <summary>
+/// Nonunique index implementation based on <see cref="Lookup{TKey, TElement}"/>
+/// </summary>
+internal class NonUniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimaryKey, TElement, TIndexKey>
+    where TPrimaryKey : notnull
+    where TIndexKey : notnull
+{
+    private readonly DataStructures.Lookup<TIndexKey, TElement> _data = new();
+    private readonly Func<TElement, TIndexKey> _keyAccessor;
+
+    public NonUniqueIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(name)
+    {
+        _keyAccessor = keyAccessor;
+    }
+
+    public override void Add(TElement value)
+    {
+        TIndexKey key = _keyAccessor(value);
+        _ = _data.Add(key, value);
+    }
+
+    public override void Remove(TElement value)
+    {
+        TIndexKey key = _keyAccessor(value);
+        _ = _data.Remove(key, value);
+    }
+
+    internal override TElement Single(TIndexKey indexKey)
+    {
+        return _data.GetValues(indexKey).Single();
+    }
+
+    internal override IEnumerable<TElement> Where(TIndexKey indexKey)
+    {
+        return _data.GetValues(indexKey);
+    }
+}

--- a/Akade.IndexedSet/Indices/RangeIndex.cs
+++ b/Akade.IndexedSet/Indices/RangeIndex.cs
@@ -11,7 +11,7 @@ internal class RangeIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimar
 {
     private readonly SortedLookup<TIndexKey, TElement> _lookup;
 
-    public RangeIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(keyAccessor, name)
+    public RangeIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(name)
     {
         _lookup = new SortedLookup<TIndexKey, TElement>(keyAccessor);
     }
@@ -26,9 +26,9 @@ internal class RangeIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimar
         _ = _lookup.Remove(value);
     }
 
-    internal override IEnumerable<TElement> Range(TIndexKey inclusiveStart, TIndexKey exclusiveStart)
+    internal override IEnumerable<TElement> Range(TIndexKey start, TIndexKey end, bool inclusiveStart, bool inclusiveEnd)
     {
-        return _lookup.GetValuesInRange(inclusiveStart, exclusiveStart);
+        return _lookup.GetValuesInRange(start, end, inclusiveStart, inclusiveEnd);
     }
 
     internal override TElement Single(TIndexKey indexKey)

--- a/Akade.IndexedSet/Indices/RangeIndex.cs
+++ b/Akade.IndexedSet/Indices/RangeIndex.cs
@@ -40,4 +40,90 @@ internal class RangeIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimar
     {
         return _lookup.GetValues(indexKey);
     }
+
+    internal override IEnumerable<TElement> GreaterThan(TIndexKey value)
+    {
+        if (_lookup.Count == 0)
+        {
+            return Enumerable.Empty<TElement>();
+        }
+
+        TIndexKey maxKey = _lookup.GetMaximumKey();
+
+        return Comparer<TIndexKey>.Default.Compare(value, maxKey) >= 0
+            ? Enumerable.Empty<TElement>()
+            : _lookup.GetValuesInRange(value, maxKey, false, true);
+    }
+
+    internal override IEnumerable<TElement> GreaterThanOrEqual(TIndexKey value)
+    {
+        if (_lookup.Count == 0)
+        {
+            return Enumerable.Empty<TElement>();
+        }
+
+        TIndexKey maxKey = _lookup.GetMaximumKey();
+
+        return Comparer<TIndexKey>.Default.Compare(value, maxKey) > 0
+            ? Enumerable.Empty<TElement>()
+            : _lookup.GetValuesInRange(value, maxKey, true, true);
+    }
+
+    internal override IEnumerable<TElement> LessThan(TIndexKey value)
+    {
+        if (_lookup.Count == 0)
+        {
+            return Enumerable.Empty<TElement>();
+        }
+
+        TIndexKey minKey = _lookup.GetMinimumKey();
+
+        return Comparer<TIndexKey>.Default.Compare(value, minKey) <= 0
+            ? Enumerable.Empty<TElement>()
+            : _lookup.GetValuesInRange(minKey, value, true, false);
+    }
+
+    internal override IEnumerable<TElement> LessThanOrEqual(TIndexKey value)
+    {
+        if (_lookup.Count == 0)
+        {
+            return Enumerable.Empty<TElement>();
+        }
+
+        TIndexKey? minKey = _lookup.GetMinimumKey();
+
+        return Comparer<TIndexKey>.Default.Compare(value, minKey) < 0
+            ? Enumerable.Empty<TElement>()
+            : _lookup.GetValuesInRange(minKey, value, true, true);
+    }
+
+    internal override TIndexKey Max()
+    {
+        return _lookup.GetMaximumKey();
+    }
+
+    internal override TIndexKey Min()
+    {
+        return _lookup.GetMinimumKey();
+    }
+
+    internal override IEnumerable<TElement> MaxBy()
+    {
+        return _lookup.GetMaximumValues();
+    }
+
+    internal override IEnumerable<TElement> MinBy()
+    {
+        return _lookup.GetMinimumValues();
+    }
+
+    internal override IEnumerable<TElement> OrderBy(int skip)
+    {
+        return _lookup.GetValues(skip..);
+    }
+
+    internal override IEnumerable<TElement> OrderByDescending(int skip)
+    {
+        return _lookup.GetValuesDescending(skip..);
+    }
 }

--- a/Akade.IndexedSet/Indices/TypedIndex.cs
+++ b/Akade.IndexedSet/Indices/TypedIndex.cs
@@ -7,16 +7,34 @@ internal abstract class TypedIndex<TPrimaryKey, TElement, TIndexKey> : Index<TPr
     where TPrimaryKey : notnull
     where TIndexKey : notnull
 {
-    protected readonly Func<TElement, TIndexKey> _keyAccessor;
-
-    protected TypedIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(name)
+    protected TypedIndex(string name) : base(name)
     {
-        _keyAccessor = keyAccessor;
+
     }
 
     internal abstract TElement Single(TIndexKey indexKey);
 
     internal abstract IEnumerable<TElement> Where(TIndexKey indexKey);
 
-    internal abstract IEnumerable<TElement> Range(TIndexKey inclusiveStart, TIndexKey exclusiveStart);
+    internal virtual IEnumerable<TElement> Range(TIndexKey start, TIndexKey end, bool inclusiveStart, bool inclusiveEnd)
+    {
+        throw new NotSupportedException($"Range queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> LessThan(TIndexKey value)
+    {
+        throw new NotSupportedException($"LessThan queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> LessThanOrEqual(TIndexKey value){
+        throw new NotSupportedException($"LessThanOrEquals queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> GreaterThan(TIndexKey value){
+        throw new NotSupportedException($"GreaterThan queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> GreaterThanOrEqual(TIndexKey value){
+        throw new NotSupportedException($"GreaterThanOrEqual queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
 }

--- a/Akade.IndexedSet/Indices/TypedIndex.cs
+++ b/Akade.IndexedSet/Indices/TypedIndex.cs
@@ -26,15 +26,48 @@ internal abstract class TypedIndex<TPrimaryKey, TElement, TIndexKey> : Index<TPr
         throw new NotSupportedException($"LessThan queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> LessThanOrEqual(TIndexKey value){
+    internal virtual IEnumerable<TElement> LessThanOrEqual(TIndexKey value)
+    {
         throw new NotSupportedException($"LessThanOrEquals queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> GreaterThan(TIndexKey value){
+    internal virtual IEnumerable<TElement> GreaterThan(TIndexKey value)
+    {
         throw new NotSupportedException($"GreaterThan queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> GreaterThanOrEqual(TIndexKey value){
+    internal virtual IEnumerable<TElement> GreaterThanOrEqual(TIndexKey value)
+    {
         throw new NotSupportedException($"GreaterThanOrEqual queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual TIndexKey Min()
+    {
+        throw new NotSupportedException($"Min queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual TIndexKey Max()
+    {
+        throw new NotSupportedException($"Max queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> MinBy()
+    {
+        throw new NotSupportedException($"MinBy queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> MaxBy()
+    {
+        throw new NotSupportedException($"MaxBy queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> OrderBy(int skip)
+    {
+        throw new NotSupportedException($"OrderBy queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
+    }
+
+    internal virtual IEnumerable<TElement> OrderByDescending(int skip)
+    {
+        throw new NotSupportedException($"OrderByDescending queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
 }

--- a/Akade.IndexedSet/Indices/UniqueIndex.cs
+++ b/Akade.IndexedSet/Indices/UniqueIndex.cs
@@ -8,10 +8,11 @@ internal class UniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrima
     where TIndexKey : notnull
 {
     private readonly Dictionary<TIndexKey, TElement> _data = new();
+    private readonly Func<TElement, TIndexKey> _keyAccessor;
 
-    public UniqueIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(keyAccessor, name)
+    public UniqueIndex(Func<TElement, TIndexKey> keyAccessor, string name) : base(name)
     {
-
+        _keyAccessor = keyAccessor;
     }
 
     public override void Add(TElement value)
@@ -31,11 +32,6 @@ internal class UniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrima
     {
         TIndexKey key = _keyAccessor(value);
         _ = _data.Remove(key);
-    }
-
-    internal override IEnumerable<TElement> Range(TIndexKey inclusiveStart, TIndexKey exclusiveStart)
-    {
-        throw new NotSupportedException($"Range queries are not supported on {nameof(MultiValueIndex<TPrimaryKey, TElement, TIndexKey>)}-indices. Use a range index to support this scenario.");
     }
 
     internal override TElement Single(TIndexKey indexKey)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ IEnumerable<GraphNode> nodesThatConnectTo1 = set.FullScan().Where(x => x.Connect
 ```
 
 ### Range index
-Binary-heap based O(log(n)) access for range based, smaller than (or equals) or bigger than (or equals) queries.
+Binary-heap based O(log(n)) access for range based, smaller than (or equals) or bigger than (or equals) and orderby queries. Also useful to do paging sorted on exactly one property.
 
 ```csharp
 var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
@@ -123,6 +123,13 @@ set.Add(new(primaryKey: 2, secondaryKey: 4));
 
 // fast access via range query
 IEnumerable<Data> data = set.Range(x => x.SecondaryKey, 1, 5);
+
+// fast max & min key value or elements
+int maxKey = set.Max(x => x.SecondaryKey);
+data = set.MaxBy(x => x.SecondaryKey);
+
+// fast larger or smaller than
+
 ```
 For more samples, checkout the unit tests.
 
@@ -167,7 +174,9 @@ Potential features:
 - Thread-safe version
 - Easier updating of keys
 - Events for changed values
-- More index types
+- More index types (Trie)
+- Tree-based range index for better insertion performance
+
 - Benchmarks
 
 If you have any suggestion or found a bug / unexpected behavior, open an issue!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![NuGet version (Akade.IndexedSet)](https://img.shields.io/nuget/v/Akade.IndexedSet.svg)
 
 Provides an In-Memory data structure, the IndexedSet, that allows to easily add indices to allow efficient querying. Based on often seeing inefficient usage of 
-`.FirstOrDefault`, `.Where`, `.Single` etc... and implementing a data-structure to improve those queries for every project I'm on.
+`.FirstOrDefault`, `.Where`, `.Single` etc... and implementing data-structures to improve those queries for every project I'm on.
 
 ## Overview
 
@@ -13,13 +13,14 @@ Performance / Operation-Support of the different indices:
 - n: total number of elements
 - m: number of elements in the return set
 
-| Query  | Unique-Index | NonUnique-Index | Range-Index     |
-| ------ | ------------ | --------------- | --------------- |
-| Single | ✔ O(1)      | ⚠ O(1)         | ⚠ O(1)         |
-| Where  | ❌           | ✔ O(m)         | ✔ O(log n + m) |
-| Range  | ❌           | ❌             | ✔ O(log n + m) |
-| < / <= | ❌           | ❌             | ✔ O(log n + m) |
-| > / >= | ❌           | ❌             | ✔ O(log n + m) |
+| Query   | Unique-Index | NonUnique-Index | Range-Index     |
+| ------  | ------------ | --------------- | --------------- |
+| Single  | ✔ O(1)      | ⚠ O(1)         | ⚠ O(1)         |
+| Where   | ❌           | ✔ O(m)         | ✔ O(log n + m) |
+| Range   | ❌           | ❌             | ✔ O(log n + m) |
+| < / <=  | ❌           | ❌             | ✔ O(log n + m) |
+| > / >=  | ❌           | ❌             | ✔ O(log n + m) |
+| OrderBy | ❌           | ❌             | ✔ O(m)         |
 
 ## FAQs
 
@@ -129,9 +130,12 @@ int maxKey = set.Max(x => x.SecondaryKey);
 data = set.MaxBy(x => x.SecondaryKey);
 
 // fast larger or smaller than
+data = set.LessThan(x => x.SecondaryKey, 4);
 
+// fast ordering & paging
+data = set.OrderBy(x => x.SecondaryKey, skip: 10).Take(10); // second page of 10 elements
 ```
-For more samples, checkout the unit tests.
+For more samples, take a look at the unit tests.
 
 ### Computed or compound key
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,56 @@
-# Akade.IndexedSet
+﻿# Akade.IndexedSet
 
 [![CI Build](https://github.com/akade/Akade.IndexedSet/actions/workflows/ci-build.yml/badge.svg?branch=master)](https://github.com/akade/Akade.IndexedSet/actions/workflows/ci-build.yml)
 ![NuGet version (Akade.IndexedSet)](https://img.shields.io/nuget/v/Akade.IndexedSet.svg)
 
 Provides an In-Memory data structure, the IndexedSet, that allows to easily add indices to allow efficient querying. Based on often seeing inefficient usage of 
-`.FirstOrDefault?`, `.Where`, `.Single` etc... and implementing such a data-structure for every project I'm on.
+`.FirstOrDefault`, `.Where`, `.Single` etc... and implementing a data-structure to improve those queries for every project I'm on.
+
+## Overview
+
+Performance / Operation-Support of the different indices:
+
+- n: total number of elements
+- m: number of elements in the return set
+
+| Query  | Unique-Index | NonUnique-Index | Range-Index     |
+| ------ | ------------ | --------------- | --------------- |
+| Single | ✔ O(1)      | ⚠ O(1)         | ⚠ O(1)         |
+| Where  | ❌           | ✔ O(m)         | ✔ O(log n + m) |
+| Range  | ❌           | ❌             | ✔ O(log n + m) |
+| < / <= | ❌           | ❌             | ✔ O(log n + m) |
+| > / >= | ❌           | ❌             | ✔ O(log n + m) |
+
+## FAQs
+
+### How do I use multiple index types for the same property?
+
+Use "named" indices by using static methods:
+
+```csharp
+record Data(int Id, int SecondaryKey);
+
+static sealed class DataIndices
+{
+        public int UniqueIndex(Data x) => x.SecondaryKey;
+}
+
+var set = IndexedSetBuilder<Data>.Create(x => x.PrimaryKey)
+           .WithUniqueIndex(DataIndices.UniqueIndex)
+           .WithRangeIndex(x => x.SecondaryKey)
+           .Build();
+
+// querying unique index:
+var data = set.Single(DataIndices.UniqueIndex, 4); // Uses the unique index
+var data2 = set.Range(x => x.SecondaryKey, 4); // Uses the range index
+var inRange = set.Range(x => x.SecondaryKey, 1, 10) // Uses the range index
+```
+
+> ℹ We recommend using the lambda syntax for "simple" properties and static methods for more complicated ones. It's easy to read, resembles "normal" LINQ-Queries and all the magic strings are compiler generated.
 
 ## Features
 This project aims to provide a data structure (*it's not a DB!*) that allows to easily setup fast access on different properties:
-### Unique index
+### Unique index (single entity, singkle key)
 Dictionary-based, O(1), access on primary and secondary keys:
 
 ```csharp
@@ -25,8 +67,8 @@ var data = set[1];
 var data = set.Single(x => x.SecondaryKey, 5);
 ```
 
-### Non-unqiue index
-Dictionary-based, O(1), access on keys with multiple values:
+### Non-unqiue index (multiple entities, single key)
+Dictionary-based, O(1), access on keys (single value) with multiple values (multiple keys):
 
 ```csharp
 var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
@@ -37,11 +79,39 @@ set.Add(new(primaryKey: 1, secondaryKey: 5));
 set.Add(new(primaryKey: 2, secondaryKey: 5));
 
 // fast access via secondary key
-IEnumerable<Data> data = set.Where(x => x.SecondaryKey, 42);
+IEnumerable<Data> data = set.Where(x => x.SecondaryKey, 5);
+```
+
+### Non-unique index (multiple entities, multiple keys)
+Dictionary-based, O(1), access on denormalized keys i.e. multiple keys for multiple entities:
+```csharp
+
+var set = IndexedSetBuilder<GraphNode>.Create(a => a.Id)
+        .WithIndex(x => x.ConnectsTo) // Where ConnectsTo returns an IEnumerable<int>
+        .Build();
+
+//   1   2
+//   |\ /
+//   | 3
+//    \|
+//     4
+
+set.Add(new(Id: 1, connectsTo: new[]{ 3, 4 }));
+set.Add(new(Id: 2, connectsTo: new[]{ 3 }));
+set.Add(new(Id: 3, connectsTo: new[]{ 1, 2 , 3 }));
+set.Add(new(Id: 4, connectsTo: new[]{ 1, 3 }));
+
+// fast access via secondary key
+// TODO: Should maybe be named contains, even if it is technically the same (or just an alias?)
+IEnumerable<GraphNode> nodesThatConnectTo1 = set.Where(x => x.ConnectsTo, 1); // returns nodes 3 & 4
+IEnumerable<GraphNode> nodesThatConnectTo3 = set.Where(x => x.ConnectsTo, 1); // returns nodes 1 & 2 & 3
+
+// Optimizes a Where(x => x.Contains(...)) query:
+IEnumerable<GraphNode> nodesThatConnectTo1 = set.FullScan().Where(x => x.ConnectsTo.Contains(1)); // returns nodes 3 & 4, but enumerates through the entire set
 ```
 
 ### Range index
-Binary-heap based O(log(n)) access for range based queries.
+Binary-heap based O(log(n)) access for range based, smaller than (or equals) or bigger than (or equals) queries.
 
 ```csharp
 var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
@@ -51,11 +121,10 @@ var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
 set.Add(new(primaryKey: 1, secondaryKey: 3));
 set.Add(new(primaryKey: 2, secondaryKey: 4));
 
-// fast access via secondary key
+// fast access via range query
 IEnumerable<Data> data = set.Range(x => x.SecondaryKey, 1, 5);
 ```
 For more samples, checkout the unit tests.
-
 
 ### Computed or compound key
 
@@ -79,10 +148,16 @@ IEnumerable<Data> data = set.Where(x => ComputedKey.SomeStaticMethod, 42);
 ### Reflection- & expression-free - convention-based index naming
 
 We are using the [CallerArgumentExpression](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callerargumentexpressionattribute)-Feature 
-of .Net 6 to provide a convention-based naming of the indices:
-- `set.Where(x => (x.Prop1, x.Prop2), (1, 2))` results in an index named `"x => (x.Prop1, x.Prop2), (1, 2))"`
-- `set.Where(ComputedKeys.NumberOfDays, 5)` results in an index named `"ComputedKeys.NumberOfDays"`
+of .Net 6/C# 10 to provide convention-based naming of the indices:
+- `set.Where(x => (x.Prop1, x.Prop2), (1, 2))` tries to use an index named `"x => (x.Prop1, x.Prop2)"`
+- `set.Where(ComputedKeys.NumberOfDays, 5)` tries to use an index named `"ComputedKeys.NumberOfDays"`
 - **Hence, be careful what you pass in. The convention is to always use a lambda with x as variable name or use static methods.**
+
+Reasons
+- Simple and yet effective:
+  - Allows computed, compund, custom values to be indexed...
+- Performance: No reflection at work and no (runtime) code-gen necessary
+- AOT-friendly
 
 ### Updating key-values
 **The current implementation requires any keys of any type to never change the value while the instance is within the set**. Hence, in order to update any key you will need to remove the instance, update the keys and add the instance again.
@@ -96,4 +171,3 @@ Potential features:
 - Benchmarks
 
 If you have any suggestion or found a bug / unexpected behavior, open an issue!
-

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Performance / Operation-Support of the different indices:
 | < / <=  | ❌           | ❌             | ✔ O(log n + m) |
 | > / >=  | ❌           | ❌             | ✔ O(log n + m) |
 | OrderBy | ❌           | ❌             | ✔ O(m)         |
+| Max/Min | ❌           | ❌             | ✔ O(1)         |
 
 ## FAQs
 
@@ -51,7 +52,7 @@ var inRange = set.Range(x => x.SecondaryKey, 1, 10) // Uses the range index
 
 ## Features
 This project aims to provide a data structure (*it's not a DB!*) that allows to easily setup fast access on different properties:
-### Unique index (single entity, singkle key)
+### Unique index (single entity, single key)
 Dictionary-based, O(1), access on primary and secondary keys:
 
 ```csharp
@@ -68,7 +69,7 @@ var data = set[1];
 var data = set.Single(x => x.SecondaryKey, 5);
 ```
 
-### Non-unqiue index (multiple entities, single key)
+### Non-unique index (multiple entities, single key)
 Dictionary-based, O(1), access on keys (single value) with multiple values (multiple keys):
 
 ```csharp
@@ -112,7 +113,7 @@ IEnumerable<GraphNode> nodesThatConnectTo1 = set.FullScan().Where(x => x.Connect
 ```
 
 ### Range index
-Binary-heap based O(log(n)) access for range based, smaller than (or equals) or bigger than (or equals) and orderby queries. Also useful to do paging sorted on exactly one property.
+Binary-heap based O(log(n)) access for range based, smaller than (or equals) or bigger than (or equals) and orderby queries. Also useful to do paging sorted on exactly one index.
 
 ```csharp
 var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
@@ -139,7 +140,7 @@ For more samples, take a look at the unit tests.
 
 ### Computed or compound key
 
-The data structure also allows to use computed or compund keys:
+The data structure also allows to use computed or compound keys:
 
 ```csharp
 var set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
@@ -166,7 +167,7 @@ of .Net 6/C# 10 to provide convention-based naming of the indices:
 
 Reasons
 - Simple and yet effective:
-  - Allows computed, compund, custom values to be indexed...
+  - Allows computed, compound, custom values to be indexed...
 - Performance: No reflection at work and no (runtime) code-gen necessary
 - AOT-friendly
 

--- a/generate_coverage.ps1
+++ b/generate_coverage.ps1
@@ -1,0 +1,5 @@
+Remove-Item Akade.IndexedSet.Tests\TestResults -Recurse
+dotnet test --collect "XPlat Code Coverage"
+$coverageReport = Get-Childitem -Path Akade.IndexedSet.Tests/TestResults -Include coverage.cobertura.xml -Recurse | select -expand FullName
+dotnet reportgenerator -reports:"$coverageReport" -targetdir:"coveragereport" -reporttypes:Html
+Invoke-Item coveragereport/index.html


### PR DESCRIPTION
v0.2 brings a bunch of new features:

Range Queries
- GreaterThan(OrEqual) and LessThan(OrEqual)
- Max(By)/Min(By) to quickly get the biggest or smallest value / element
- OrderBy(Descending) for efficient **paging** support: `indexedSet.OrderBy(x => x.Prop, skip: 10).Take(10)`

Non-unique index (multiple entities, multiple keys)
- **New** index type to allow indexing `IEnumerable<T>` properties to improve `.Where(x => x.List.Contains(...))`-queries: ìndexedSet.Where(x => x.List, contains: ...)` will use the appropriate index.