### PR TITLE
"PrimaryKey-less" sets

### DIFF
--- a/Akade.IndexedSet.Tests/Samples/Appointments/AppointmentSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Appointments/AppointmentSample.cs
@@ -31,16 +31,16 @@ public class AppointmentSample
 
         foreach (DateOnly day in days)
         {
-            _appointments.Add(new(id++, "Daily", "Lancelot", day.WithDayTime(09, 00), day.WithDayTime(09, 15)));
+            _ = _appointments.Add(new(id++, "Daily", "Lancelot", day.WithDayTime(09, 00), day.WithDayTime(09, 15)));
         }
-        _appointments.Add(new(id++, "Weekly", "Cinderella", days[0].WithDayTime(10, 00), days[0].WithDayTime(11, 15)));
+        _ = _appointments.Add(new(id++, "Weekly", "Cinderella", days[0].WithDayTime(10, 00), days[0].WithDayTime(11, 15)));
 
-        _appointments.Add(new(id++, "Iteration Planning", "Esmeralda", days[2].WithDayTime(09, 15), days[2].WithDayTime(16, 15)));
+        _ = _appointments.Add(new(id++, "Iteration Planning", "Esmeralda", days[2].WithDayTime(09, 15), days[2].WithDayTime(16, 15)));
 
-        _appointments.Add(new(id++, "Discuss Technical Debt #42", "Lancelot", days[3].WithDayTime(11, 00), days[3].WithDayTime(11, 45)));
+        _ = _appointments.Add(new(id++, "Discuss Technical Debt #42", "Lancelot", days[3].WithDayTime(11, 00), days[3].WithDayTime(11, 45)));
 
 
-        _appointments.Add(new(id++, "Discuss Issue #1234", "Esmeralda", days[4].WithDayTime(09, 15), days[4].WithDayTime(10, 00)));
+        _ = _appointments.Add(new(id++, "Discuss Issue #1234", "Esmeralda", days[4].WithDayTime(09, 15), days[4].WithDayTime(10, 00)));
 
     }
 

--- a/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Graph/GraphSample.cs
@@ -13,10 +13,10 @@ public class GraphSample
                                                               .WithIndex<int>(x => x.ConnectedTo) // for special collections such as immutable arrays: make sure the correct overload has been selected by providing generic arguments
                                                               .Build();
 
-        _graph.Add(new Node(id: 1, connectedTo: ImmutableArray.Create(2, 3, 4)));
-        _graph.Add(new Node(id: 2, connectedTo: ImmutableArray.Create(1, 2)));
-        _graph.Add(new Node(id: 3, connectedTo: ImmutableArray.Create(2, 4)));
-        _graph.Add(new Node(id: 4, connectedTo: ImmutableArray.Create(2, 3, 1)));
+        _ = _graph.Add(new Node(id: 1, connectedTo: ImmutableArray.Create(2, 3, 4)));
+        _ = _graph.Add(new Node(id: 2, connectedTo: ImmutableArray.Create(1, 2)));
+        _ = _graph.Add(new Node(id: 3, connectedTo: ImmutableArray.Create(2, 4)));
+        _ = _graph.Add(new Node(id: 4, connectedTo: ImmutableArray.Create(2, 3, 1)));
 
         // fast variant via index
         var fastResult = _graph.Where(x => x.ConnectedTo, contains: 4)

--- a/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Leaderboard/LeaderboardSample.cs
@@ -21,7 +21,7 @@ public class LeaderboardSample
             int daysInPast = i / 24;
             int hour = i % 24;
 
-            _leaderboard.Add(new LeaderboardEntry(i, i * i, _now.AddDays(-daysInPast).AddHours(hour)));
+            _ = _leaderboard.Add(new LeaderboardEntry(i, i * i, _now.AddDays(-daysInPast).AddHours(hour)));
         }
     }
 

--- a/Akade.IndexedSet.Tests/Samples/Readme.cs
+++ b/Akade.IndexedSet.Tests/Samples/Readme.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Akade.IndexedSet.Tests.Samples;
+
+
+[TestClass]
+public class Readme
+{
+    private record Data(int PrimaryKey, int SecondaryKey);
+
+    [TestMethod]
+    public void Features_UniqueIndex()
+    {
+        IndexedSet<int, Data> set = IndexedSetBuilder<Data>.Create(a => a.PrimaryKey)
+                                                           .WithUniqueIndex(x => x.SecondaryKey)
+                                                           .Build();
+
+        _ = set.Add(new(PrimaryKey: 1, SecondaryKey: 5));
+
+        // fast access via primary key
+        Data data = set[1];
+
+        // fast access via secondary key
+        data = set.Single(x => x.SecondaryKey, 5);
+    }
+
+    [TestMethod]
+    public void Features_NonUniqueIndex_SingleKey()
+    {
+        IndexedSet<int, Data>? set = new Data[] { new(PrimaryKey: 1, SecondaryKey: 5), new(PrimaryKey: 2, SecondaryKey: 5) }
+            .ToIndexedSet(x => x.PrimaryKey)
+            .WithIndex(x => x.SecondaryKey)
+            .Build();
+
+        // fast access via secondary key
+        IEnumerable<Data> data = set.Where(x => x.SecondaryKey, 5);
+    }
+
+    private record GraphNode(int Id, IEnumerable<int> ConnectsTo);
+
+
+    [TestMethod]
+    public void Features_NonUniqueIndex_MultipleKeys()
+    {
+        IndexedSet<int, GraphNode> set = IndexedSetBuilder<GraphNode>.Create(a => a.Id)
+                                                                     .WithIndex(x => x.ConnectsTo) // Where ConnectsTo returns an IEnumerable<int>
+                                                                     .Build();
+
+        //   1   2
+        //   |\ /
+        //   | 3
+        //    \|
+        //     4
+
+        _ = set.Add(new(Id: 1, ConnectsTo: new[] { 3, 4 }));
+        _ = set.Add(new(Id: 2, ConnectsTo: new[] { 3 }));
+        _ = set.Add(new(Id: 3, ConnectsTo: new[] { 1, 2, 3 }));
+        _ = set.Add(new(Id: 4, ConnectsTo: new[] { 1, 3 }));
+
+        // For readability, it is recommended to write the name for the parameter contains
+        IEnumerable<GraphNode> nodesThatConnectTo1 = set.Where(x => x.ConnectsTo, contains: 1); // returns nodes 3 & 4
+        IEnumerable<GraphNode> nodesThatConnectTo3 = set.Where(x => x.ConnectsTo, contains: 1); // returns nodes 1 & 2 & 3
+
+        // Non-optimized Where(x => x.Contains(...)) query:
+        nodesThatConnectTo1 = set.FullScan().Where(x => x.ConnectsTo.Contains(1)); // returns nodes 3 & 4, but enumerates through the entire set
+    }
+
+    [TestMethod]
+    public void Features_RangeIndex()
+    {
+        IndexedSet<Data> set = IndexedSetBuilder.Create(new Data[] { new(1, SecondaryKey: 3), new(2, SecondaryKey: 4) })
+                                                .WithRangeIndex(x => x.SecondaryKey)
+                                                .Build();
+
+        // fast access via range query
+        IEnumerable<Data> data = set.Range(x => x.SecondaryKey, 1, 5);
+
+        // fast max & min key value or elements
+        int maxKey = set.Max(x => x.SecondaryKey);
+        data = set.MaxBy(x => x.SecondaryKey);
+
+        // fast larger or smaller than
+        data = set.LessThan(x => x.SecondaryKey, 4);
+
+        // fast ordering & paging
+        data = set.OrderBy(x => x.SecondaryKey, skip: 10).Take(10); // second page of 10 elements
+    }
+
+    public record RangeData(int Start, int End);
+
+    [TestMethod]
+    public void Features_ComputedOrCompoundKey()
+    {
+        var data = new RangeData[] { new(Start: 2, End: 10) };
+        IndexedSet<RangeData> set = data.ToIndexedSet()
+                                        .WithIndex(x => (x.Start, x.End))
+                                        .WithIndex(x => x.End - x.Start)
+                                        .WithIndex(ComputedKey.SomeStaticMethod)
+                                        .Build();
+        // fast access via indices
+        IEnumerable<RangeData> result = set.Where(x => (x.Start, x.End), (2, 10));
+        result = set.Where(x => x.End - x.Start, 8);
+        result = set.Where(ComputedKey.SomeStaticMethod, 42);
+    }
+
+
+    [TestMethod]
+    public void FAQ_MultipleIndicesForSameProperty()
+    {
+        IndexedSet<int, Data> set = IndexedSetBuilder<Data>.Create(x => x.PrimaryKey)
+                                                           .WithUniqueIndex(DataIndices.UniqueIndex)
+                                                           .WithRangeIndex(x => x.SecondaryKey)
+                                                           .Build();
+        _ = set.Add(new(1, 4));
+        // querying unique index:
+        Data data = set.Single(DataIndices.UniqueIndex, 4); // Uses the unique index
+        Data data2 = set.Single(x => x.SecondaryKey, 4); // Uses the range index
+        IEnumerable<Data> inRange = set.Range(x => x.SecondaryKey, 1, 10); // Uses the range index
+    }
+
+    private record Purchase(int Id, int ProductId, int Amount, decimal UnitPrice);
+
+    [TestMethod]
+    public void Overview()
+    {
+        var data = new Purchase[] {
+            new(Id: 1, ProductId: 1, Amount: 1, UnitPrice: 5),
+            new(Id: 2, ProductId: 1, Amount: 2, UnitPrice: 5),
+            new(Id: 6, ProductId: 4, Amount: 3, UnitPrice: 12),
+            new(Id: 7, ProductId: 4, Amount: 8, UnitPrice: 10) // discounted price
+            };
+
+        IndexedSet<int, Purchase> set = data.ToIndexedSet(x => x.Id)
+                                            .WithIndex(x => x.ProductId)
+                                            .WithRangeIndex(x => x.Amount)
+                                            .WithRangeIndex(x => x.UnitPrice)
+                                            .WithRangeIndex(x => x.Amount * x.UnitPrice)
+                                            .WithIndex(x => (x.ProductId, x.UnitPrice))
+                                            .Build();
+
+        // efficient queries on configured indices
+        _ = set.Where(x => x.ProductId, 4);
+        _ = set.Range(x => x.Amount, 1, 3, inclusiveStart: true, inclusiveEnd: true);
+        _ = set.GreaterThanOrEqual(x => x.UnitPrice, 10);
+        _ = set.MaxBy(x => x.Amount * x.UnitPrice);
+        _ = set.Where(x => (x.ProductId, x.UnitPrice), (4, 10));
+    }
+
+    private static class DataIndices
+    {
+        public static int UniqueIndex(Data x)
+        {
+            return x.SecondaryKey;
+        }
+    }
+
+    private static class ComputedKey
+    {
+        public static int SomeStaticMethod(RangeData data)
+        {
+            return data.Start * data.End;
+        }
+    }
+}

--- a/Akade.IndexedSet.Tests/TestsWithoutIndices.cs
+++ b/Akade.IndexedSet.Tests/TestsWithoutIndices.cs
@@ -23,13 +23,13 @@ public class TestsWithoutIndices
     {
         Assert.AreEqual(0, _indexedSet.Count);
 
-        _indexedSet.Add(_a);
+        _ = _indexedSet.Add(_a);
         Assert.AreEqual(1, _indexedSet.Count);
 
-        _indexedSet.Add(_b);
+        _ = _indexedSet.Add(_b);
         Assert.AreEqual(2, _indexedSet.Count);
 
-        _indexedSet.Add(_c);
+        _ = _indexedSet.Add(_c);
         Assert.AreEqual(3, _indexedSet.Count);
     }
 
@@ -88,17 +88,24 @@ public class TestsWithoutIndices
     }
 
     [TestMethod]
+    public void adding_duplicate_item_returns_false()
+    {
+        AddAll();
+        Assert.IsFalse(_indexedSet.Add(_a));
+    }
+
+    [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void adding_duplicate_primary_key_throws()
     {
         AddAll();
-        _indexedSet.Add(_a);
+        _ = _indexedSet.Add(new TestData(0, 0, Guid.Empty, ""));
     }
 
     private void AddAll()
     {
-        _indexedSet.Add(_a);
-        _indexedSet.Add(_b);
-        _indexedSet.Add(_c);
+        _ = _indexedSet.Add(_a);
+        _ = _indexedSet.Add(_b);
+        _ = _indexedSet.Add(_c);
     }
 }

--- a/Akade.IndexedSet.Tests/UniqueIndices.cs
+++ b/Akade.IndexedSet.Tests/UniqueIndices.cs
@@ -71,7 +71,7 @@ public class UniqueIndices
     [ExpectedException(typeof(ArgumentException))]
     public void adding_duplicate_key_throws()
     {
-        _indexedSet.Add(new TestData(5, 10, Guid.NewGuid(), "ew"));
+        _ = _indexedSet.Add(new TestData(5, 10, Guid.NewGuid(), "ew"));
     }
 
     [TestMethod]

--- a/Akade.IndexedSet/DataStructures/Lookup.cs
+++ b/Akade.IndexedSet/DataStructures/Lookup.cs
@@ -32,6 +32,11 @@ internal class Lookup<TKey, TValue>
         return _values.TryGetValue(key, out HashSet<TValue>? keySet) ? keySet : Enumerable.Empty<TValue>();
     }
 
+    public int CountValues(TKey key)
+    {
+        return _values.TryGetValue(key, out HashSet<TValue>? keySet) ? keySet.Count : 0;
+    }
+
     public bool Remove(TKey key, TValue value)
     {
         if (!_values.TryGetValue(key, out HashSet<TValue>? keySet))

--- a/Akade.IndexedSet/DataStructures/SortedLookup.cs
+++ b/Akade.IndexedSet/DataStructures/SortedLookup.cs
@@ -64,7 +64,12 @@ internal class SortedLookup<TKey, TValue>
     {
         Range range = _sortedKeys.GetRange(key);
         return GetValues(range);
+    }
 
+    public int CountValues(TKey key)
+    {
+        Range range = _sortedKeys.GetRange(key);
+        return range.GetOffsetAndLength(_sortedKeys.Count).Length;
     }
 
     public IEnumerable<TValue> GetValuesInRange(TKey start, TKey end, bool inclusiveStart, bool inclusiveEnd)

--- a/Akade.IndexedSet/IndexedSetBuilder.cs
+++ b/Akade.IndexedSet/IndexedSetBuilder.cs
@@ -43,7 +43,7 @@ public static class IndexedSetBuilder
     /// <summary>
     /// Creates a new builder instance with the given initial content
     /// </summary>
-    public static IndexedSetBuilder<TElement> ToIndexedSet<TPrimaryKey, TElement>(this IEnumerable<TElement> initialContent)
+    public static IndexedSetBuilder<TElement> ToIndexedSet<TElement>(this IEnumerable<TElement> initialContent)
     {
         return new IndexedSetBuilder<TElement>(null, initialContent);
     }

--- a/Akade.IndexedSet/Indices/Index.cs
+++ b/Akade.IndexedSet/Indices/Index.cs
@@ -3,8 +3,7 @@
 /// <summary>
 /// Non-generic on the index key to have a strongly typed base class for an index
 /// </summary>
-internal abstract class Index<TPrimaryKey, TElement>
-    where TPrimaryKey : notnull
+internal abstract class Index<TElement>
 {
     public string Name { get; }
 
@@ -18,6 +17,8 @@ internal abstract class Index<TPrimaryKey, TElement>
     public virtual void AddRange(IEnumerable<TElement> elementsToAdd)
     {
         foreach (TElement element in elementsToAdd)
+        {
             Add(element);
+        }
     }
 }

--- a/Akade.IndexedSet/Indices/NonUniqueIndex.cs
+++ b/Akade.IndexedSet/Indices/NonUniqueIndex.cs
@@ -3,8 +3,7 @@
 /// <summary>
 /// Nonunique index implementation based on <see cref="Lookup{TKey, TElement}"/>
 /// </summary>
-internal class NonUniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimaryKey, TElement, TIndexKey>
-    where TPrimaryKey : notnull
+internal class NonUniqueIndex<TElement, TIndexKey> : TypedIndex<TElement, TIndexKey>
     where TIndexKey : notnull
 {
     private readonly DataStructures.Lookup<TIndexKey, TElement> _data = new();
@@ -40,6 +39,19 @@ internal class NonUniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPr
     internal override TElement Single(TIndexKey indexKey)
     {
         return _data.GetValues(indexKey).Single();
+    }
+
+    internal override bool TryGetSingle(TIndexKey indexKey, out TElement? element)
+    {
+        element = default;
+
+        if (_data.CountValues(indexKey) == 1)
+        {
+            element = _data.GetValues(indexKey).Single();
+            return true;
+        }
+
+        return false;
     }
 
     internal override IEnumerable<TElement> Where(TIndexKey indexKey)

--- a/Akade.IndexedSet/Indices/RangeIndex.cs
+++ b/Akade.IndexedSet/Indices/RangeIndex.cs
@@ -5,8 +5,7 @@ namespace Akade.IndexedSet.Indices;
 /// <summary>
 /// O(log(n)) range queries based on <see cref="SortedLookup{TKey, TValue}"/>.
 /// </summary>
-internal class RangeIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimaryKey, TElement, TIndexKey>
-    where TPrimaryKey : notnull
+internal class RangeIndex<TElement, TIndexKey> : TypedIndex<TElement, TIndexKey>
     where TIndexKey : notnull
 {
     private readonly SortedLookup<TIndexKey, TElement> _lookup;
@@ -39,6 +38,19 @@ internal class RangeIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimar
     internal override TElement Single(TIndexKey indexKey)
     {
         return _lookup.GetValues(indexKey).Single();
+    }
+
+    internal override bool TryGetSingle(TIndexKey indexKey, out TElement? element)
+    {
+        element = default;
+
+        if (_lookup.CountValues(indexKey) == 1)
+        {
+            element = _lookup.GetValues(indexKey).Single();
+            return true;
+        }
+
+        return false;
     }
 
     internal override IEnumerable<TElement> Where(TIndexKey indexKey)

--- a/Akade.IndexedSet/Indices/TypedIndex.cs
+++ b/Akade.IndexedSet/Indices/TypedIndex.cs
@@ -3,8 +3,7 @@
 /// <summary>
 /// Fully-generic index including on the index key
 /// </summary>
-internal abstract class TypedIndex<TPrimaryKey, TElement, TIndexKey> : Index<TPrimaryKey, TElement>
-    where TPrimaryKey : notnull
+internal abstract class TypedIndex<TElement, TIndexKey> : Index<TElement>
     where TIndexKey : notnull
 {
     protected TypedIndex(string name) : base(name)
@@ -70,4 +69,6 @@ internal abstract class TypedIndex<TPrimaryKey, TElement, TIndexKey> : Index<TPr
     {
         throw new NotSupportedException($"OrderByDescending queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
+
+    internal abstract bool TryGetSingle(TIndexKey indexKey, out TElement? element);
 }

--- a/Akade.IndexedSet/Indices/UniqueIndex.cs
+++ b/Akade.IndexedSet/Indices/UniqueIndex.cs
@@ -3,8 +3,7 @@
 /// <summary>
 /// Unique index providing O(1) retrieval and insertion as well as enforcing unqueness
 /// </summary>
-internal class UniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrimaryKey, TElement, TIndexKey>
-    where TPrimaryKey : notnull
+internal class UniqueIndex<TElement, TIndexKey> : TypedIndex<TElement, TIndexKey>
     where TIndexKey : notnull
 {
     private readonly Dictionary<TIndexKey, TElement> _data = new();
@@ -31,7 +30,9 @@ internal class UniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrima
     public override void AddRange(IEnumerable<TElement> elementsToAdd)
     {
         if (elementsToAdd.TryGetNonEnumeratedCount(out int count))
+        {
             _ = _data.EnsureCapacity(_data.Count + count);
+        }
 
         base.AddRange(elementsToAdd);
     }
@@ -45,6 +46,11 @@ internal class UniqueIndex<TPrimaryKey, TElement, TIndexKey> : TypedIndex<TPrima
     internal override TElement Single(TIndexKey indexKey)
     {
         return _data[indexKey];
+    }
+
+    internal override bool TryGetSingle(TIndexKey indexKey, out TElement? element)
+    {
+        return _data.TryGetValue(indexKey, out element);
     }
 
     internal override IEnumerable<TElement> Where(TIndexKey indexKey)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Potential features (not ordered):
 - [ ] Tree-based range index for better insertion performance
 - [ ] Analyzers to help with best practices
 - [x] Range insertion and corresponding `.ToIndexedSet().WithIndex(x => ...).[...].Build()`
-- [ ] Refactoring to allow a primarykey-less set: this is an artifical restriction that is not necessary
+- [x] Refactoring to allow a primarykey-less set: this was an artifical restriction that is not necessary
 - [ ] Aggregates (i.e. sum or average: interface based on state & add/removal state update functions)
 - [ ] Benchmarks
 


### PR DESCRIPTION
- Refactored creation & set to support indexedsets for data without a primary key as well
- `IndexedSet<TData>` for sets without a primary key
- `IndexedSet<TPrimaryKey, TData>` for sets with a primary key