### PR TITLE
ReadOnlyMemory<char> switched to String/ReadOnlySpan<char>

### DIFF
--- a/Akade.IndexedSet.Benchmarks/Akade.IndexedSet.Benchmarks.csproj
+++ b/Akade.IndexedSet.Benchmarks/Akade.IndexedSet.Benchmarks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
   </ItemGroup>

--- a/Akade.IndexedSet.Benchmarks/ConcurrentSetBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/ConcurrentSetBenchmarks.cs
@@ -22,13 +22,13 @@ public class ConcurrentSetBenchmarks
 
         _indexedSet = _persons.ToIndexedSet()
                               .WithUniqueIndex(x => x.Phone)
-                              .WithFullTextIndex(x => x.FullName.AsMemory())
+                              .WithFullTextIndex(x => x.FullName)
                               .WithRangeIndex(GetAge)
                               .Build();
 
         _concurrentIndexedSet = _persons.ToIndexedSet()
                                         .WithUniqueIndex(x => x.Phone)
-                                        .WithFullTextIndex(x => x.FullName.AsMemory())
+                                        .WithFullTextIndex(x => x.FullName)
                                         .WithRangeIndex(GetAge)
                                         .BuildConcurrent();
     }
@@ -77,13 +77,13 @@ public class ConcurrentSetBenchmarks
     [BenchmarkCategory("FullText")]
     public int FullTextLookup()
     {
-        return _indexedSet.FuzzyContains(x => x.FullName.AsMemory(), "Peter".AsMemory(), 1).Count();
+        return _indexedSet.FuzzyContains(x => x.FullName, "Peter", 1).Count();
     }
 
     [Benchmark]
     [BenchmarkCategory("FullText")]
     public int ConcurrentFullTextLookup()
     {
-        return _concurrentIndexedSet.FuzzyContains(x => x.FullName.AsMemory(), "Peter".AsMemory(), 1).Count();
+        return _concurrentIndexedSet.FuzzyContains(x => x.FullName, "Peter", 1).Count();
     }
 }

--- a/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
@@ -19,7 +19,7 @@ public class FullTextIndexBenchmarks
                                          .Generate(1000);
 
         _indexedSet = _document.ToIndexedSet()
-                               .WithFullTextIndex(x => x.Content.AsMemory())
+                               .WithFullTextIndex(x => x.Content)
                                .Build();
 
     }
@@ -35,7 +35,7 @@ public class FullTextIndexBenchmarks
     [BenchmarkCategory("Contains")]
     public int Contains_IndexedSet()
     {
-        return _indexedSet.Contains(x => x.Content.AsMemory(), "excellent".AsMemory()).Count();
+        return _indexedSet.Contains(x => x.Content, "excellent").Count();
     }
 
     [Benchmark(Baseline = true)]
@@ -65,6 +65,6 @@ public class FullTextIndexBenchmarks
     [BenchmarkCategory("Fuzzy Contains")]
     public int FuzzyContains_IndexedSet()
     {
-        return _indexedSet.FuzzyContains(x => x.Content.AsMemory(), "excellent".AsMemory(), 2).Count();
+        return _indexedSet.FuzzyContains(x => x.Content, "excellent", 2).Count();
     }
 }

--- a/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
@@ -18,7 +18,7 @@ public class PrefixIndexBenchmarks
                              .ToList();
 
         _indexedSet = _persons.ToIndexedSet()
-                              .WithPrefixIndex(x => x.FullName.AsMemory())
+                              .WithPrefixIndex(x => x.FullName)
                               .Build();
     }
 
@@ -33,7 +33,7 @@ public class PrefixIndexBenchmarks
     [BenchmarkCategory("StartsWith")]
     public int StartsWith_IndexedSet()
     {
-        return _indexedSet.StartsWith(x => x.FullName.AsMemory(), "Peter".AsMemory()).Count();
+        return _indexedSet.StartsWith(x => x.FullName, "Peter").Count();
     }
 
     [Benchmark(Baseline = true)]
@@ -47,6 +47,6 @@ public class PrefixIndexBenchmarks
     [BenchmarkCategory("Fuzzy StartsWith")]
     public int FuzzyStartsWith_IndexedSet()
     {
-        return _indexedSet.FuzzyStartsWith(x => x.FullName.AsMemory(), "Peter".AsMemory(), 2).Count();
+        return _indexedSet.FuzzyStartsWith(x => x.FullName, "Peter", 2).Count();
     }
 }

--- a/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
+++ b/Akade.IndexedSet.Tests/Akade.IndexedSet.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="34.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/Akade.IndexedSet.Tests/Concurrency/ConcurrentSetTests.cs
+++ b/Akade.IndexedSet.Tests/Concurrency/ConcurrentSetTests.cs
@@ -78,7 +78,7 @@ public class ConcurrentSetTests
     {
         return IndexedSetBuilder<Person>.Create()
                                         .WithUniqueIndex(x => x.Phone)
-                                        .WithPrefixIndex(x => x.FullName.AsMemory())
+                                        .WithPrefixIndex(x => x.FullName)
                                         .WithIndex(x => x.Company)
                                         .BuildConcurrent();
     }

--- a/Akade.IndexedSet.Tests/FullTextIndices.cs
+++ b/Akade.IndexedSet.Tests/FullTextIndices.cs
@@ -21,7 +21,6 @@ public class FullTextIndices
     private readonly Animal _pangolin = new("Pangolin", "Mammal");
     private readonly Animal _parrot = new("Parrot", "Bird");
 
-
     [TestInitialize]
     public void Init()
     {
@@ -39,58 +38,56 @@ public class FullTextIndices
             _parrot,
         };
         _indexedSet = data.ToIndexedSet()
-                          .WithFullTextIndex(x => x.Category.AsMemory())
-                          .WithFullTextIndex(x => x.Name.AsMemory())
+                          .WithFullTextIndex(x => x.Category)
+                          .WithFullTextIndex(x => x.Name)
                           .Build();
     }
 
     [TestMethod]
     public void single_item_retrieval_works()
     {
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _boomslang);
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _tarantula);
+        _indexedSet.AssertSingleItem(x => x.Category, _boomslang);
+        _indexedSet.AssertSingleItem(x => x.Category, _tarantula);
     }
 
     [TestMethod]
     [ExpectedException(typeof(InvalidOperationException))]
     public void single_item_retrieval_throws_exception_if_there_is_more_than_one_result()
     {
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _bonobo);
+        _indexedSet.AssertSingleItem(x => x.Category, _bonobo);
     }
 
     [TestMethod]
     public void multi_item_retrieval_works()
     {
-        _indexedSet.AssertMultipleItems(x => x.Category.AsMemory(), expectedElements: new[] { _bonobo, _borador, _tiger, _tapir, _panther, _pangolin });
-        _indexedSet.AssertMultipleItems(x => x.Category.AsMemory(), expectedElements: new[] { _booby, _penguin, _parrot });
+        _indexedSet.AssertMultipleItems(x => x.Category, expectedElements: new[] { _bonobo, _borador, _tiger, _tapir, _panther, _pangolin });
+        _indexedSet.AssertMultipleItems(x => x.Category, expectedElements: new[] { _booby, _penguin, _parrot });
     }
 
     [TestMethod]
     public void search_via_starts_with()
     {
-        CollectionAssert.AreEquivalent(new[] { _booby, _boomslang }, _indexedSet.StartsWith(x => x.Name.AsMemory(), "Boo".AsMemory()).ToArray());
-        CollectionAssert.AreEquivalent(new[] { _panther, _pangolin }, _indexedSet.StartsWith(x => x.Name.AsMemory(), "Pan".AsMemory()).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _booby, _boomslang }, _indexedSet.StartsWith(x => x.Name, "Boo").ToArray());
+        CollectionAssert.AreEquivalent(new[] { _panther, _pangolin }, _indexedSet.StartsWith(x => x.Name, "Pan").ToArray());
     }
-
 
     [TestMethod]
     public void search_via_fuzzy_starts_with()
     {
-        CollectionAssert.AreEquivalent(new[] { _bonobo, _booby, _boomslang, _borador }, _indexedSet.FuzzyStartsWith(x => x.Name.AsMemory(), "Boo".AsMemory(), 1).ToArray());
-        CollectionAssert.AreEquivalent(new[] { _penguin, _parrot, _panther, _pangolin }, _indexedSet.FuzzyStartsWith(x => x.Name.AsMemory(), "Pan".AsMemory(), 1).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _bonobo, _booby, _boomslang, _borador }, _indexedSet.FuzzyStartsWith(x => x.Name, "Boo", 1).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _penguin, _parrot, _panther, _pangolin }, _indexedSet.FuzzyStartsWith(x => x.Name, "Pan", 1).ToArray());
     }
 
     [TestMethod]
     public void search_via_contains()
     {
-        CollectionAssert.AreEquivalent(new[] { _boomslang, _tarantula, _panther, _pangolin }, _indexedSet.Contains(x => x.Name.AsMemory(), "an".AsMemory()).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _boomslang, _tarantula, _panther, _pangolin }, _indexedSet.Contains(x => x.Name, "an").ToArray());
     }
-
 
     [TestMethod]
     public void search_via_fuzzy_contains()
     {
-        Animal[] actual = _indexedSet.FuzzyContains(x => x.Name.AsMemory(), "Pan".AsMemory(), 1).ToArray();
+        Animal[] actual = _indexedSet.FuzzyContains(x => x.Name, "Pan", 1).ToArray();
         CollectionAssert.AreEquivalent(new[] { _boomslang, _tarantula, _penguin, _parrot, _panther, _pangolin }, actual);
     }
 }

--- a/Akade.IndexedSet.Tests/GeneralTests.cs
+++ b/Akade.IndexedSet.Tests/GeneralTests.cs
@@ -22,7 +22,7 @@ public class GeneralTests
                           .WithIndex(x => x.IntProperty)
                           .WithIndex(x => x.WritableProperty)
                           .WithRangeIndex(x => x.GuidProperty)
-                          .WithFullTextIndex(x => x.StringProperty.AsMemory())
+                          .WithFullTextIndex(x => x.StringProperty)
                           .Build();
     }
 

--- a/Akade.IndexedSet.Tests/PrefixIndices.cs
+++ b/Akade.IndexedSet.Tests/PrefixIndices.cs
@@ -21,7 +21,6 @@ public class PrefixIndices
     private readonly Animal _pangolin = new("Pangolin", "Mammal");
     private readonly Animal _parrot = new("Parrot", "Bird");
 
-
     [TestInitialize]
     public void Init()
     {
@@ -39,44 +38,43 @@ public class PrefixIndices
             _parrot,
         };
         _indexedSet = data.ToIndexedSet()
-                          .WithPrefixIndex(x => x.Category.AsMemory())
-                          .WithPrefixIndex(x => x.Name.AsMemory())
+                          .WithPrefixIndex(x => x.Category)
+                          .WithPrefixIndex(x => x.Name)
                           .Build();
     }
 
     [TestMethod]
     public void single_item_retrieval_works()
     {
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _boomslang);
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _tarantula);
+        _indexedSet.AssertSingleItem(x => x.Category, _boomslang);
+        _indexedSet.AssertSingleItem(x => x.Category, _tarantula);
     }
 
     [TestMethod]
     [ExpectedException(typeof(InvalidOperationException))]
     public void single_item_retrieval_throws_exception_if_there_is_more_than_one_result()
     {
-        _indexedSet.AssertSingleItem(x => x.Category.AsMemory(), _bonobo);
+        _indexedSet.AssertSingleItem(x => x.Category, _bonobo);
     }
 
     [TestMethod]
     public void multi_item_retrieval_works()
     {
-        _indexedSet.AssertMultipleItems(x => x.Category.AsMemory(), expectedElements: new[] { _bonobo, _borador, _tiger, _tapir, _panther, _pangolin });
-        _indexedSet.AssertMultipleItems(x => x.Category.AsMemory(), expectedElements: new[] { _booby, _penguin, _parrot });
+        _indexedSet.AssertMultipleItems(x => x.Category, expectedElements: new[] { _bonobo, _borador, _tiger, _tapir, _panther, _pangolin });
+        _indexedSet.AssertMultipleItems(x => x.Category, expectedElements: new[] { _booby, _penguin, _parrot });
     }
 
     [TestMethod]
     public void search_via_starts_with()
     {
-        CollectionAssert.AreEquivalent(new[] { _booby, _boomslang }, _indexedSet.StartsWith(x => x.Name.AsMemory(), "Boo".AsMemory()).ToArray());
-        CollectionAssert.AreEquivalent(new[] { _panther, _pangolin }, _indexedSet.StartsWith(x => x.Name.AsMemory(), "Pan".AsMemory()).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _booby, _boomslang }, _indexedSet.StartsWith(x => x.Name, "Boo").ToArray());
+        CollectionAssert.AreEquivalent(new[] { _panther, _pangolin }, _indexedSet.StartsWith(x => x.Name, "Pan").ToArray());
     }
-
 
     [TestMethod]
     public void search_via_fuzzy_starts_with()
     {
-        CollectionAssert.AreEquivalent(new[] { _bonobo, _booby, _boomslang, _borador }, _indexedSet.FuzzyStartsWith(x => x.Name.AsMemory(), "Boo".AsMemory(), 1).ToArray());
-        CollectionAssert.AreEquivalent(new[] { _penguin, _parrot, _panther, _pangolin }, _indexedSet.FuzzyStartsWith(x => x.Name.AsMemory(), "Pan".AsMemory(), 1).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _bonobo, _booby, _boomslang, _borador }, _indexedSet.FuzzyStartsWith(x => x.Name, "Boo", 1).ToArray());
+        CollectionAssert.AreEquivalent(new[] { _penguin, _parrot, _panther, _pangolin }, _indexedSet.FuzzyStartsWith(x => x.Name, "Pan", 1).ToArray());
     }
 }

--- a/Akade.IndexedSet.Tests/Samples/Appointments/AppointmentSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/Appointments/AppointmentSample.cs
@@ -19,7 +19,7 @@ public class AppointmentSample
         .WithRangeIndex(x => x.Start)
         .WithRangeIndex(x => x.End)
         .WithRangeIndex(Duration) // calculated property
-        .WithFullTextIndex(x => x.Subject.AsMemory())
+        .WithFullTextIndex(x => x.Subject)
         .Build();
 
     public AppointmentSample()
@@ -40,11 +40,9 @@ public class AppointmentSample
 
         _ = _appointments.Add(new(id++, "Discuss Technical Debt #42", "Lancelot", days[3].WithDayTime(11, 00), days[3].WithDayTime(11, 45)));
 
-
         _ = _appointments.Add(new(id++, "Discuss Issue #1234", "Esmeralda", days[4].WithDayTime(09, 15), days[4].WithDayTime(10, 00)));
 
     }
-
 
     [TestMethod]
     public void get_all_meetings_for_owner()
@@ -54,7 +52,6 @@ public class AppointmentSample
         Assert.AreEqual(2, _appointments.Where(x => x.Owner, "Esmeralda").Count());
         Assert.AreEqual(1, _appointments.Where(x => x.Owner, "Cinderella").Count());
     }
-
 
     [TestMethod]
     public void get_all_meetings_today_or_tomorrow()
@@ -114,7 +111,7 @@ public class AppointmentSample
     public void text_searching_within_subjects()
     {
         // querying within the full-text-search index allows to perform a contains over a trie instead of comparing it on all elements
-        Appointment meetingWith42InSubject = _appointments.Contains(x => x.Subject.AsMemory(), "#42".AsMemory()).Single();
+        Appointment meetingWith42InSubject = _appointments.Contains(x => x.Subject, "#42").Single();
         Assert.IsTrue(meetingWith42InSubject.Subject.Contains("#42"));
     }
 
@@ -122,7 +119,7 @@ public class AppointmentSample
     public void fuzzy_searching_within_subjects()
     {
         // Fulltext and prefix indices support fuzzy matching to allow a certain number of errors (Levenshtein/edit distance)
-        Appointment technicalDebtMeeting = _appointments.FuzzyContains(x => x.Subject.AsMemory(), "Technical Det".AsMemory(), 1).Single();
+        Appointment technicalDebtMeeting = _appointments.FuzzyContains(x => x.Subject, "Technical Det", 1).Single();
 
         Assert.IsFalse(technicalDebtMeeting.Subject.Contains("Technical Det"));
         Assert.IsTrue(technicalDebtMeeting.Subject.Contains("Technical Debt"));

--- a/Akade.IndexedSet.Tests/Samples/Readme.cs
+++ b/Akade.IndexedSet.Tests/Samples/Readme.cs
@@ -110,18 +110,18 @@ public class Readme
     {
         IndexedSet<Type> data = typeof(object).Assembly.GetTypes()
                                                        .ToIndexedSet()
-                                                       .WithPrefixIndex(x => x.Name.AsMemory())
-                                                       .WithFullTextIndex(x => x.FullName.AsMemory())
+                                                       .WithPrefixIndex(x => x.Name)
+                                                       .WithFullTextIndex(x => x.FullName!)
                                                        .Build();
 
         // fast prefix or contains queries via indices
-        _ = data.StartsWith(x => x.Name.AsMemory(), "Int".AsMemory());
-        _ = data.Contains(x => x.FullName.AsMemory(), "Int".AsMemory());
+        _ = data.StartsWith(x => x.Name, "Int");
+        _ = data.Contains(x => x.FullName!, "Int");
 
         // fuzzy searching is supported by prefix and full text indices
         // the following will also match "String"
-        _ = data.FuzzyStartsWith(x => x.Name.AsMemory(), "Strang".AsMemory(), 1);
-        _ = data.FuzzyContains(x => x.FullName.AsMemory(), "Strang".AsMemory(), 1);
+        _ = data.FuzzyStartsWith(x => x.Name, "Strang", 1);
+        _ = data.FuzzyContains(x => x.FullName!, "Strang", 1);
     }
 
     [TestMethod]
@@ -142,9 +142,9 @@ public class Readme
     public void FAQ_CaseInsensitiveFuzzyMatching()
     {
         IndexedSet<Data> set = IndexedSetBuilder<Data>.Create(x => x.PrimaryKey)
-                                                      .WithFullTextIndex(x => x.Text.ToLowerInvariant().AsMemory())
+                                                      .WithFullTextIndex(x => x.Text.ToLowerInvariant())
                                                       .Build();
-        IEnumerable<Data> matches = set.FuzzyContains(x => x.Text.ToLowerInvariant().AsMemory(), "Search".AsMemory(), maxDistance: 2);
+        IEnumerable<Data> matches = set.FuzzyContains(x => x.Text.ToLowerInvariant(), "Search", maxDistance: 2);
     }
 
     [TestMethod]

--- a/Akade.IndexedSet.Tests/Samples/TypeaheadSample/TypeaheadSample.cs
+++ b/Akade.IndexedSet.Tests/Samples/TypeaheadSample/TypeaheadSample.cs
@@ -11,7 +11,7 @@ public class TypeaheadSample
     {
         _types = typeof(string).Assembly.GetTypes()
                                         .ToIndexedSet()
-                                        .WithPrefixIndex(x => x.Name.ToLowerInvariant().AsMemory())
+                                        .WithPrefixIndex(x => x.Name.ToLowerInvariant())
                                         .Build();
     }
 
@@ -19,7 +19,7 @@ public class TypeaheadSample
     public void Case_insensitve_lookahead_in_all_types_within_system_runtime()
     {
         // Travers the prefix trie to efficiently find all matches
-        Type[] types = _types.StartsWith(x => x.Name.ToLowerInvariant().AsMemory(), "int".AsMemory()).ToArray();
+        Type[] types = _types.StartsWith(x => x.Name.ToLowerInvariant(), "int").ToArray();
 
         Assert.IsTrue(types.Any());
         Assert.IsTrue(types.All(t => t.Name.StartsWith("int", StringComparison.InvariantCultureIgnoreCase)));

--- a/Akade.IndexedSet/Concurrency/ConcurrentIndexedSet.cs
+++ b/Akade.IndexedSet/Concurrency/ConcurrentIndexedSet.cs
@@ -391,8 +391,8 @@ public class ConcurrentIndexedSet<TElement>
     /// <param name="prefix">The prefix to use</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     public IEnumerable<TElement> StartsWith(
-        Func<TElement, ReadOnlyMemory<char>> indexAccessor,
-        ReadOnlyMemory<char> prefix,
+        Func<TElement, string> indexAccessor,
+        ReadOnlySpan<char> prefix,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
         using (AcquireReaderLock())
@@ -410,8 +410,8 @@ public class ConcurrentIndexedSet<TElement>
     /// <param name="maxDistance">The maximum distance (e.g. Levenshtein) between the input prefix and matches</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     public IEnumerable<TElement> FuzzyStartsWith(
-        Func<TElement, ReadOnlyMemory<char>> indexAccessor,
-        ReadOnlyMemory<char> prefix,
+        Func<TElement, string> indexAccessor,
+        ReadOnlySpan<char> prefix,
         int maxDistance,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
@@ -429,8 +429,8 @@ public class ConcurrentIndexedSet<TElement>
     /// <param name="infix">The infix to use</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     public IEnumerable<TElement> Contains(
-        Func<TElement, ReadOnlyMemory<char>> indexAccessor,
-        ReadOnlyMemory<char> infix,
+        Func<TElement, string> indexAccessor,
+        ReadOnlySpan<char> infix,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
         using (AcquireReaderLock())
@@ -448,8 +448,8 @@ public class ConcurrentIndexedSet<TElement>
     /// <param name="maxDistance">The maximum distance (e.g. Levenshtein) between the input infix and matches</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     public IEnumerable<TElement> FuzzyContains(
-        Func<TElement, ReadOnlyMemory<char>> indexAccessor,
-        ReadOnlyMemory<char> infix,
+        Func<TElement, string> indexAccessor,
+        ReadOnlySpan<char> infix,
         int maxDistance,
         [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {

--- a/Akade.IndexedSet/IndexedSet.cs
+++ b/Akade.IndexedSet/IndexedSet.cs
@@ -388,9 +388,9 @@ public class IndexedSet<TElement>
     /// <param name="prefix">The prefix to use</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
-    public IEnumerable<TElement> StartsWith(Func<TElement, ReadOnlyMemory<char>> indexAccessor, ReadOnlyMemory<char> prefix, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+    public IEnumerable<TElement> StartsWith(Func<TElement, string> indexAccessor, ReadOnlySpan<char> prefix, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
-        TypedIndex<TElement, ReadOnlyMemory<char>> typedIndex = GetIndex<ReadOnlyMemory<char>>(indexName);
+        TypedIndex<TElement, string> typedIndex = GetIndex<string>(indexName);
         return typedIndex.StartsWith(prefix);
     }
 
@@ -403,9 +403,9 @@ public class IndexedSet<TElement>
     /// <param name="maxDistance">The maximum distance (e.g. Levenshtein) between the input prefix and matches</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
-    public IEnumerable<TElement> FuzzyStartsWith(Func<TElement, ReadOnlyMemory<char>> indexAccessor, ReadOnlyMemory<char> prefix, int maxDistance, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+    public IEnumerable<TElement> FuzzyStartsWith(Func<TElement, string> indexAccessor, ReadOnlySpan<char> prefix, int maxDistance, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
-        TypedIndex<TElement, ReadOnlyMemory<char>> typedIndex = GetIndex<ReadOnlyMemory<char>>(indexName);
+        TypedIndex<TElement, string> typedIndex = GetIndex<string>(indexName);
         return typedIndex.FuzzyStartsWith(prefix, maxDistance);
     }
 
@@ -417,9 +417,9 @@ public class IndexedSet<TElement>
     /// <param name="infix">The infix to use</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
-    public IEnumerable<TElement> Contains(Func<TElement, ReadOnlyMemory<char>> indexAccessor, ReadOnlyMemory<char> infix, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+    public IEnumerable<TElement> Contains(Func<TElement, string> indexAccessor, ReadOnlySpan<char> infix, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
-        TypedIndex<TElement, ReadOnlyMemory<char>> typedIndex = GetIndex<ReadOnlyMemory<char>>(indexName);
+        TypedIndex<TElement, string> typedIndex = GetIndex<string>(indexName);
         return typedIndex.Contains(infix);
     }
 
@@ -432,9 +432,9 @@ public class IndexedSet<TElement>
     /// <param name="maxDistance">The maximum distance (e.g. Levenshtein) between the input infix and matches</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used as caller argument expression")]
-    public IEnumerable<TElement> FuzzyContains(Func<TElement, ReadOnlyMemory<char>> indexAccessor, ReadOnlyMemory<char> infix, int maxDistance, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+    public IEnumerable<TElement> FuzzyContains(Func<TElement, string> indexAccessor, ReadOnlySpan<char> infix, int maxDistance, [CallerArgumentExpression("indexAccessor")] string? indexName = null)
     {
-        TypedIndex<TElement, ReadOnlyMemory<char>> typedIndex = GetIndex<ReadOnlyMemory<char>>(indexName);
+        TypedIndex<TElement, string> typedIndex = GetIndex<string>(indexName);
         return typedIndex.FuzzyContains(infix, maxDistance);
     }
 

--- a/Akade.IndexedSet/IndexedSetBuilder.cs
+++ b/Akade.IndexedSet/IndexedSetBuilder.cs
@@ -196,7 +196,7 @@ public class IndexedSetBuilder<TElement>
     /// Hence, the convention is to always use x as an identifier in case a lambda expression is used.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="keyAccessor"/> is automatically passed by the compiler.</param>
     /// <returns>The instance on which this method is called is returned to support the fluent syntax.</returns>
-    public virtual IndexedSetBuilder<TElement> WithFullTextIndex(Func<TElement, ReadOnlyMemory<char>> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
+    public virtual IndexedSetBuilder<TElement> WithFullTextIndex(Func<TElement, string> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
     {
         if (indexName is null)
         {
@@ -219,7 +219,7 @@ public class IndexedSetBuilder<TElement>
     /// Hence, the convention is to always use x as an identifier in case a lambda expression is used.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="keyAccessor"/> is automatically passed by the compiler.</param>
     /// <returns>The instance on which this method is called is returned to support the fluent syntax.</returns>
-    public virtual IndexedSetBuilder<TElement> WithPrefixIndex(Func<TElement, ReadOnlyMemory<char>> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
+    public virtual IndexedSetBuilder<TElement> WithPrefixIndex(Func<TElement, string> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
     {
         if (indexName is null)
         {
@@ -294,14 +294,14 @@ public class IndexedSetBuilder<TPrimaryKey, TElement> : IndexedSetBuilder<TEleme
     }
 
     /// <inheritdoc />
-    public override IndexedSetBuilder<TPrimaryKey, TElement> WithFullTextIndex(Func<TElement, ReadOnlyMemory<char>> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
+    public override IndexedSetBuilder<TPrimaryKey, TElement> WithFullTextIndex(Func<TElement, string> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
     {
         _ = base.WithFullTextIndex(keyAccessor, indexName);
         return this;
     }
 
     /// <inheritdoc />
-    public override IndexedSetBuilder<TPrimaryKey, TElement> WithPrefixIndex(Func<TElement, ReadOnlyMemory<char>> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
+    public override IndexedSetBuilder<TPrimaryKey, TElement> WithPrefixIndex(Func<TElement, string> keyAccessor, [CallerArgumentExpression("keyAccessor")] string? indexName = null)
     {
         _ = base.WithPrefixIndex(keyAccessor, indexName);
         return this;

--- a/Akade.IndexedSet/Indices/PrefixIndex.cs
+++ b/Akade.IndexedSet/Indices/PrefixIndex.cs
@@ -1,12 +1,12 @@
 ﻿using Akade.IndexedSet.DataStructures;
 
 namespace Akade.IndexedSet.Indices;
-internal class PrefixIndex<TElement> : TypedIndex<TElement, ReadOnlyMemory<char>>
+internal class PrefixIndex<TElement> : TypedIndex<TElement, string>
 {
     private readonly Trie<TElement> _trie;
-    private readonly Func<TElement, ReadOnlyMemory<char>> _keyAccessor;
+    private readonly Func<TElement, string> _keyAccessor;
 
-    public PrefixIndex(Func<TElement, ReadOnlyMemory<char>> keyAccessor, string name) : base(name)
+    public PrefixIndex(Func<TElement, string> keyAccessor, string name) : base(name)
     {
         _keyAccessor = keyAccessor;
         _trie = new();
@@ -14,24 +14,24 @@ internal class PrefixIndex<TElement> : TypedIndex<TElement, ReadOnlyMemory<char>
 
     public override void Add(TElement value)
     {
-        ReadOnlyMemory<char> key = _keyAccessor(value);
-        _ = _trie.Add(key.Span, value);
+        string key = _keyAccessor(value);
+        _ = _trie.Add(key, value);
     }
 
     public override void Remove(TElement value)
     {
-        ReadOnlyMemory<char> key = _keyAccessor(value);
-        _ = _trie.Remove(key.Span, value);
+        string key = _keyAccessor(value);
+        _ = _trie.Remove(key, value);
     }
 
-    internal override TElement Single(ReadOnlyMemory<char> indexKey)
+    internal override TElement Single(string indexKey)
     {
-        return _trie.GetAll(indexKey.Span).Single();
+        return _trie.GetAll(indexKey).Single();
     }
 
-    internal override bool TryGetSingle(ReadOnlyMemory<char> indexKey, out TElement? element)
+    internal override bool TryGetSingle(string indexKey, out TElement? element)
     {
-        IEnumerable<TElement> allMatches = _trie.Get(indexKey.Span);
+        IEnumerable<TElement> allMatches = _trie.Get(indexKey);
         element = default;
 
         IEnumerator<TElement> enumerator = allMatches.GetEnumerator();
@@ -46,19 +46,19 @@ internal class PrefixIndex<TElement> : TypedIndex<TElement, ReadOnlyMemory<char>
         return !enumerator.MoveNext();
     }
 
-    internal override IEnumerable<TElement> Where(ReadOnlyMemory<char> indexKey)
+    internal override IEnumerable<TElement> Where(string indexKey)
     {
-        return _trie.Get(indexKey.Span);
+        return _trie.Get(indexKey);
     }
 
-    internal override IEnumerable<TElement> StartsWith(ReadOnlyMemory<char> indexKey)
+    internal override IEnumerable<TElement> StartsWith(ReadOnlySpan<char> indexKey)
     {
-        return _trie.GetAll(indexKey.Span);
+        return _trie.GetAll(indexKey);
     }
 
-    internal override IEnumerable<TElement> FuzzyStartsWith(ReadOnlyMemory<char> indexKey, int maxDistance)
+    internal override IEnumerable<TElement> FuzzyStartsWith(ReadOnlySpan<char> indexKey, int maxDistance)
     {
-        return _trie.FuzzySearch(indexKey.Span, maxDistance, false);
+        return _trie.FuzzySearch(indexKey, maxDistance, false);
     }
 
     public override void Clear()

--- a/Akade.IndexedSet/Indices/TypedIndex.cs
+++ b/Akade.IndexedSet/Indices/TypedIndex.cs
@@ -72,22 +72,22 @@ internal abstract class TypedIndex<TElement, TIndexKey> : Index<TElement>
         throw new NotSupportedException($"OrderByDescending queries are not supported on {GetType().Name}-indices. Use a range index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> FuzzyStartsWith(ReadOnlyMemory<char> indexKey, int maxDistance)
+    internal virtual IEnumerable<TElement> FuzzyStartsWith(ReadOnlySpan<char> indexKey, int maxDistance)
     {
         throw new NotSupportedException($"Fuzzy starts with queries are not supported on {GetType().Name}-indices. Use a full text or prefix index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> FuzzyContains(ReadOnlyMemory<char> indexKey, int maxDistance)
+    internal virtual IEnumerable<TElement> FuzzyContains(ReadOnlySpan<char> indexKey, int maxDistance)
     {
         throw new NotSupportedException($"Fuzzy contains queries are not supported on {GetType().Name}-indices. Use a full text or prefix index to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> StartsWith(ReadOnlyMemory<char> indexKey)
+    internal virtual IEnumerable<TElement> StartsWith(ReadOnlySpan<char> indexKey)
     {
         throw new NotSupportedException($"Fuzzy queries are not supported on {GetType().Name}-indices. Use a full text or or prefix to support this scenario.");
     }
 
-    internal virtual IEnumerable<TElement> Contains(ReadOnlyMemory<char> indexKey)
+    internal virtual IEnumerable<TElement> Contains(ReadOnlySpan<char> indexKey)
     {
         throw new NotSupportedException($"Contain queries are not supported on {GetType().Name}-indices. Use a full text to support this scenario.");
     }

--- a/README.md
+++ b/README.md
@@ -321,10 +321,10 @@ Potential features (not ordered):
 - [x] Range insertion and corresponding `.ToIndexedSet().WithIndex(x => ...).[...].Build()`
 - [x] Refactoring to allow a primarykey-less set: this was an artifical restriction that is not necessary
 - [x] Benchmarks
+- [x] Simplification of string indices, i.e. Span/String based overloads to avoid `AsMemory()`...
 - [ ] Tree-based range index for better insertion performance
 - [ ] Analyzers to help with best practices
 - [ ] Aggregates (i.e. sum or average: interface based on state & add/removal state update functions)
 - [ ] Custom (equality) comparators for indices
-- [ ] Simplification of string indices, i.e. Span based overloads to avoid ``...
 
 If you have any suggestion or found a bug / unexpected behavior, open an issue! I will also review PRs and integrate them if they fit the project.

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -3,88 +3,88 @@ Benchmarks measured on 27.07.2022:
 
 ## Environment
 ``` ini
-BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.674)
 AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK=6.0.302
-  [Host]     : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
-  DefaultJob : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
+.NET SDK=6.0.402
+  [Host]     : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
+  DefaultJob : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
 ```
 
 All benchmarks are currenlty using *1k elements*. Benchmarks showing the scaling is on the roadmap - expect IndexedSet to scale much
 much better than the naive LINQ Queries.
 
 ## Unique-Index
-|                       Method |         Mean |     Error |    StdDev | Ratio | Code Size |  Gen 0 | Allocated |
-|----------------------------- |-------------:|----------:|----------:|------:|----------:|-------:|----------:|
-|                  Unqiue_Linq | 158,313.5 ns | 845.71 ns | 706.21 ns | 1.000 |     753 B | 0.7324 |  12,800 B |
-|            Unique_Dictionary |     478.1 ns |   0.84 ns |   0.70 ns | 0.003 |     681 B |      - |         - |
-| Unique_IndexedSet_PrimaryKey |   1,762.0 ns |  34.62 ns |  34.01 ns | 0.011 |     513 B |      - |         - |
-|     Unique_IndexedSet_Single |   1,545.8 ns |   7.05 ns |   6.60 ns | 0.010 |   1,225 B |      - |         - |
+|                       Method |         Mean |     Error |    StdDev | Ratio | Code Size |   Gen0 | Allocated | Alloc Ratio |
+|----------------------------- |-------------:|----------:|----------:|------:|----------:|-------:|----------:|------------:|
+|                  Unqiue_Linq | 165,265.0 ns | 311.89 ns | 243.51 ns | 1.000 |     753 B | 0.7324 |   12800 B |        1.00 |
+|            Unique_Dictionary |     473.9 ns |   0.44 ns |   0.39 ns | 0.003 |     681 B |      - |         - |        0.00 |
+| Unique_IndexedSet_PrimaryKey |   1,687.4 ns |   2.21 ns |   2.06 ns | 0.010 |     512 B |      - |         - |        0.00 |
+|     Unique_IndexedSet_Single |   1,561.7 ns |   4.48 ns |   4.19 ns | 0.009 |   1,224 B |      - |         - |        0.00 |
 
 > ℹ️ Note that manually maintaining a dictionary is *currently* faster but only if the executing class has direct access
 > to the dictionary. Ideas to bring it on par are being explored for scenarios with very tight loops around dictionary lookup.
 
 ## MultiValue-Index
-|                Method |     Mean |    Error |   StdDev | Ratio | Code Size |  Gen 0 | Allocated |
-|---------------------- |---------:|---------:|---------:|------:|----------:|-------:|----------:|
-|       MultiValue_Linq | 64.66 μs | 0.709 μs | 0.663 μs |  1.00 |   2,575 B |      - |   1,680 B |
-|     Multivalue_Lookup | 12.31 μs | 0.139 μs | 0.116 μs |  0.19 |   1,768 B | 0.0153 |     360 B |
-| Multivalue_IndexedSet | 13.45 μs | 0.080 μs | 0.062 μs |  0.21 |   2,728 B | 0.0153 |     360 B |
+|                Method |     Mean |    Error |   StdDev | Ratio | Code Size |   Gen0 | Allocated | Alloc Ratio |
+|---------------------- |---------:|---------:|---------:|------:|----------:|-------:|----------:|------------:|
+|       MultiValue_Linq | 58.50 μs | 0.237 μs | 0.222 μs |  1.00 |   2,575 B | 0.0610 |    1680 B |        1.00 |
+|     Multivalue_Lookup | 12.04 μs | 0.032 μs | 0.028 μs |  0.21 |   1,768 B | 0.0153 |     360 B |        0.21 |
+| Multivalue_IndexedSet | 13.10 μs | 0.139 μs | 0.116 μs |  0.22 |   2,729 B | 0.0153 |     360 B |        0.21 |
 
 > ℹ️ Solution is on par with manually using LINQ's lookup (i.e. `.ToLookup()`)
 
 ## Range-Index
-|              Method |         Mean |        Error |       StdDev | Ratio |  Gen 0 |  Gen 1 | Allocated |
-|-------------------- |-------------:|-------------:|-------------:|------:|-------:|-------:|----------:|
-|          Range_Linq | 22,643.85 ns |   211.794 ns |   187.750 ns |  1.00 |      - |      - |     168 B |
-|    Range_IndexedSet |  2,865.35 ns |     3.205 ns |     2.677 ns |  0.13 | 0.0038 |      - |      72 B |
-|                     |              |              |              |       |        |        |           |
-|         Paging_Linq | 78,183.43 ns |   845.911 ns |   749.878 ns | 1.000 | 9.5215 | 2.3193 | 160,352 B |
-|   Paging_IndexedSet |    189.49 ns |     1.085 ns |     1.015 ns | 0.002 | 0.0277 |      - |     464 B |
-|                     |              |              |              |       |        |        |           |
-|            Min_Linq | 74,497.53 ns | 1,258.503 ns | 1,177.204 ns | 1.000 |      - |      - |      40 B |
-|      Min_IndexedSet |     10.10 ns |     0.028 ns |     0.025 ns | 0.000 |      - |      - |         - |
-|                     |              |              |              |       |        |        |           |
-|       LessThan_Linq | 16,915.54 ns |   127.021 ns |   106.069 ns |  1.00 |      - |      - |     160 B |
-| LessThan_IndexedSet |  3,908.94 ns |     5.453 ns |     4.554 ns |  0.23 |      - |      - |      72 B |
+|              Method |          Mean |         Error |        StdDev | Ratio |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|-------------------- |--------------:|--------------:|--------------:|------:|-------:|-------:|----------:|------------:|
+|          Range_Linq | 23,038.455 ns |   459.8874 ns |   597.9835 ns |  1.00 |      - |      - |     168 B |        1.00 |
+|    Range_IndexedSet |  2,663.595 ns |     1.5612 ns |     1.3840 ns |  0.11 | 0.0038 |      - |      72 B |        0.43 |
+|                     |               |               |               |       |        |        |           |             |
+|         Paging_Linq | 72,168.508 ns |   229.3990 ns |   214.5800 ns | 1.000 | 9.5215 | 2.3193 |  160352 B |       1.000 |
+|   Paging_IndexedSet |    182.269 ns |     0.5060 ns |     0.4733 ns | 0.003 | 0.0277 |      - |     464 B |       0.003 |
+|                     |               |               |               |       |        |        |           |             |
+|            Min_Linq | 81,774.092 ns | 1,613.7419 ns | 1,430.5402 ns | 1.000 |      - |      - |      40 B |        1.00 |
+|      Min_IndexedSet |      9.948 ns |     0.0121 ns |     0.0114 ns | 0.000 |      - |      - |         - |        0.00 |
+|                     |               |               |               |       |        |        |           |             |
+|       LessThan_Linq | 16,925.834 ns |    60.9109 ns |    56.9761 ns |  1.00 |      - |      - |     160 B |        1.00 |
+| LessThan_IndexedSet |  3,672.340 ns |     2.1130 ns |     1.8731 ns |  0.22 | 0.0038 |      - |      72 B |        0.45 |
 
 > ℹ️ There is no built-in range data structure, hence no comparison. Paging covers sorting scenarios, while min-queries cover MinBy and MaxBy-Queries as well.
 
 ## Prefix-Index
-|                     Method |         Mean |      Error |     StdDev | Ratio |  Gen 0 | Allocated |
-|--------------------------- |-------------:|-----------:|-----------:|------:|-------:|----------:|
-|            StartsWith_Linq |  8,576.15 ns | 138.038 ns | 122.367 ns | 1.000 |      - |      40 B |
-|      StartsWith_IndexedSet |     82.25 ns |   0.308 ns |   0.273 ns | 0.010 |      - |         - |
-|                            |              |            |            |       |        |           |
-|       FuzzyStartsWith_Linq | 44,471.02 ns | 205.713 ns | 192.424 ns |  1.00 | 4.7607 |  80,040 B |
-| FuzzyStartsWith_IndexedSet | 14,699.35 ns |  73.623 ns |  68.867 ns |  0.33 | 1.3275 |  22,304 B |
+|                     Method |         Mean |      Error |     StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
+|--------------------------- |-------------:|-----------:|-----------:|------:|-------:|----------:|------------:|
+|            StartsWith_Linq |  8,660.27 ns | 151.443 ns | 141.660 ns | 1.000 |      - |      40 B |        1.00 |
+|      StartsWith_IndexedSet |     77.29 ns |   0.092 ns |   0.086 ns | 0.009 |      - |         - |        0.00 |
+|                            |              |            |            |       |        |           |             |
+|       FuzzyStartsWith_Linq | 45,732.01 ns | 141.950 ns | 132.781 ns |  1.00 | 4.7607 |   80040 B |        1.00 |
+| FuzzyStartsWith_IndexedSet | 13,112.31 ns |  81.449 ns |  76.188 ns |  0.29 | 1.3275 |   22304 B |        0.28 |
 
 > ℹ️ Fuzzy-Matching of string pairs within the Linq-Benchmark is done with [Fastenshtein](https://github.com/DanHarltey/Fastenshtein)
 
 ## FullText-Index
 
-|                   Method |           Mean |        Error |       StdDev | Ratio |    Gen 0 |   Allocated |
-|------------------------- |---------------:|-------------:|-------------:|------:|---------:|------------:|
-|            Contains_Linq |    40,012.5 ns |    410.37 ns |    363.79 ns | 1.000 |        - |        40 B |
-|      Contains_IndexedSet |       145.5 ns |      0.60 ns |      0.56 ns | 0.004 |   0.0114 |       192 B |
-|                          |                |              |              |       |          |             |
-|       FuzzyContains_Linq | 4,755,780.7 ns | 13,276.35 ns | 11,769.14 ns |  1.00 | 281.2500 | 4,831,712 B |
-| FuzzyContains_IndexedSet |   137,248.9 ns |  1,233.79 ns |    963.26 ns |  0.03 |  15.3809 |   260,624 B |
+|                   Method |           Mean |       Error |      StdDev | Ratio |     Gen0 | Allocated | Alloc Ratio |
+|------------------------- |---------------:|------------:|------------:|------:|---------:|----------:|------------:|
+|            Contains_Linq |    40,103.8 ns |   272.77 ns |   255.15 ns | 1.000 |        - |      40 B |        1.00 |
+|      Contains_IndexedSet |       139.9 ns |     0.29 ns |     0.27 ns | 0.003 |   0.0114 |     192 B |        4.80 |
+|                          |                |             |             |       |          |           |             |
+|       FuzzyContains_Linq | 5,052,830.3 ns | 8,964.55 ns | 8,385.45 ns |  1.00 | 281.2500 | 4831711 B |        1.00 |
+| FuzzyContains_IndexedSet |   133,142.1 ns |   433.97 ns |   405.94 ns |  0.03 |  15.3809 |  260624 B |        0.05 |
 
 > ℹ️ Fuzzy-Matching of string pairs within the Linq-Benchmark is done with [Fastenshtein](https://github.com/DanHarltey/Fastenshtein) and enumerating possible infixes.
 
 ## ConcurrentSet
 
-|                   Method |         Mean |     Error |    StdDev | Ratio |  Gen 0 | Allocated |
-|------------------------- |-------------:|----------:|----------:|------:|-------:|----------:|
-|             UniqueLookup |     15.60 ns |  0.044 ns |  0.041 ns |  1.00 |      - |         - |
-|   ConcurrentUniqueLookup |     34.66 ns |  0.052 ns |  0.043 ns |  2.22 |      - |         - |
-|                          |              |           |           |       |        |           |
-|           LessThanLookup |     25.64 ns |  0.131 ns |  0.116 ns |  1.00 | 0.0038 |      64 B |
-| ConcurrentLessThanLookup |     53.80 ns |  0.120 ns |  0.106 ns |  2.10 | 0.0057 |      96 B |
-|                          |              |           |           |       |        |           |
-|           FullTextLookup | 10,756.76 ns | 46.046 ns | 43.071 ns |  1.00 | 1.1444 |  19,288 B |
-| ConcurrentFullTextLookup | 11,128.86 ns | 97.457 ns | 86.393 ns |  1.03 | 1.1444 |  19,360 B |
+|                   Method |         Mean |     Error |    StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
+|------------------------- |-------------:|----------:|----------:|------:|-------:|----------:|------------:|
+|             UniqueLookup |     15.03 ns |  0.024 ns |  0.022 ns |  1.00 |      - |         - |          NA |
+|   ConcurrentUniqueLookup |     33.84 ns |  0.073 ns |  0.068 ns |  2.25 |      - |         - |          NA |
+|                          |              |           |           |       |        |           |             |
+|           LessThanLookup |     25.80 ns |  0.069 ns |  0.064 ns |  1.00 | 0.0038 |      64 B |        1.00 |
+| ConcurrentLessThanLookup |     52.88 ns |  0.086 ns |  0.080 ns |  2.05 | 0.0057 |      96 B |        1.50 |
+|                          |              |           |           |       |        |           |             |
+|             UniqueLookup |     15.03 ns |  0.024 ns |  0.022 ns |  1.00 |      - |         - |          NA |
+|   ConcurrentUniqueLookup |     33.84 ns |  0.073 ns |  0.068 ns |  2.25 |      - |         - |          NA |
 
 > ℹ️ For more complex scenarios, the synchronization cost is negligble. For simple queries, it is not.
 The difference in allocated memory is due to materialization of results in the concurrent case.


### PR DESCRIPTION
This PR switches from `ReadOnlyMemory<char>` to `String` / `ReadOnlySpan<char>` for FullText & Prefixindices. This is a **breaking change**.

The motivation for the breaking change is simplicity and having an intuitive interface. And in hindsight, using `ReadOnlyMemory<char>` can be considered premature optimization. Adding that almost all usages just pass in a `string` with `.AsMemory()` anyway, it makes no sense in keeping that.

## How to update
- Remove all usages `.AsMemory()`. Make sure to do that while building the sets as well as when querying. You can use this PR as a guideline.
- If you passed in a "real" sliced `ReadOnlyMemory<char>` you’ll need to convert it. For creating (and naming) an index, using a static method is recommended. For query parameters, you can just call `.ToString()` on it to obtain a string.