### PR TITLE
Additional TryGetSingle-Methods

### DIFF
--- a/Akade.IndexedSet.Tests/FullTextIndices.cs
+++ b/Akade.IndexedSet.Tests/FullTextIndices.cs
@@ -90,4 +90,14 @@ public class FullTextIndices
         Animal[] actual = _indexedSet.FuzzyContains(x => x.Name, "Pan", 1).ToArray();
         CollectionAssert.AreEquivalent(new[] { _boomslang, _tarantula, _penguin, _parrot, _panther, _pangolin }, actual);
     }
+
+    [TestMethod]
+    public void TryGetSingle()
+    {
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.Name, "Bonobo", out Animal? animal1));
+        Assert.IsNotNull(animal1);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.Name, "Elephant", out Animal? animal2));
+        Assert.IsNull(animal2);
+    }
 }

--- a/Akade.IndexedSet.Tests/MultiValueIndices.cs
+++ b/Akade.IndexedSet.Tests/MultiValueIndices.cs
@@ -42,4 +42,24 @@ public class MultiValueIndices
         Assert.IsFalse(_indexedSet.Remove(0));
         Assert.IsFalse(_indexedSet.Contains(0));
     }
+
+    [TestMethod]
+    public void TryGetSingle()
+    {
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.IntList, 4, out DenormalizedTestData? test1));
+        Assert.IsNotNull(test1);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntList, 1, out DenormalizedTestData? test2));
+        Assert.IsNull(test2);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntList, 5, out DenormalizedTestData? test3));
+        Assert.IsNull(test3);
+    }
+
+    [TestMethod]
+    public void Clear()
+    {
+        _indexedSet.Clear();
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntList, 1, out _));
+    }
 }

--- a/Akade.IndexedSet.Tests/NonUniqueIndices.cs
+++ b/Akade.IndexedSet.Tests/NonUniqueIndices.cs
@@ -85,4 +85,17 @@ public class NonUniqueIndices
         _indexedSet.AssertMultipleItems(x => x.StringProperty, expectedElements: new[] { _c, _d, _e });
         Assert.AreEqual(_a, _indexedSet.Where(x => x.StringProperty, "AA").Single());
     }
+
+    [TestMethod]
+    public void TryGetSingle_on_secondary_key()
+    {
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntProperty, 8, out TestData? data1));
+        Assert.IsNull(data1);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntProperty, 10, out TestData? data2));
+        Assert.IsNull(data2);
+
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.IntProperty, 11, out TestData? data3));
+        Assert.IsNotNull(data3);
+    }
 }

--- a/Akade.IndexedSet.Tests/PrefixIndices.cs
+++ b/Akade.IndexedSet.Tests/PrefixIndices.cs
@@ -77,4 +77,14 @@ public class PrefixIndices
         CollectionAssert.AreEquivalent(new[] { _bonobo, _booby, _boomslang, _borador }, _indexedSet.FuzzyStartsWith(x => x.Name, "Boo", 1).ToArray());
         CollectionAssert.AreEquivalent(new[] { _penguin, _parrot, _panther, _pangolin }, _indexedSet.FuzzyStartsWith(x => x.Name, "Pan", 1).ToArray());
     }
+
+    [TestMethod]
+    public void TryGetSingle()
+    {
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.Name, "Bonobo", out Animal? animal1));
+        Assert.IsNotNull(animal1);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.Name, "Elephant", out Animal? animal2));
+        Assert.IsNull(animal2);
+    }
 }

--- a/Akade.IndexedSet.Tests/RangeIndices.cs
+++ b/Akade.IndexedSet.Tests/RangeIndices.cs
@@ -17,7 +17,7 @@ public class RangeIndices
     [TestInitialize]
     public void Init()
     {
-        TestData[] data = new[] {_a, _b, _c, _d, _e};
+        TestData[] data = new[] { _a, _b, _c, _d, _e };
         _indexedSet = data.ToIndexedSet(x => x.PrimaryKey)
                           .WithRangeIndex(x => x.IntProperty)
                           .WithRangeIndex(x => x.GuidProperty)
@@ -61,8 +61,6 @@ public class RangeIndices
         _indexedSet.AssertMultipleItemsViaRange(x => x.GuidProperty, GuidGen.Get(5), GuidGen.Get(8), inclusiveStart: true, inclusiveEnd: false, expectedElements: new[] { _d, _e });
     }
 
-
-
     [TestMethod]
     public void retrieval_via_secondary_int_key_returns_correct_items()
     {
@@ -91,7 +89,7 @@ public class RangeIndices
     [TestMethod]
     public void retrieval_via_compound_key_returns_correct_items()
     {
-        TestData[] data = new[] {_a, _b, _c, _d, _e};
+        TestData[] data = new[] { _a, _b, _c, _d, _e };
         _indexedSet = data.ToIndexedSet(x => x.PrimaryKey)
                           .WithRangeIndex(x => (x.IntProperty, x.StringProperty))
                           .Build();
@@ -192,5 +190,18 @@ public class RangeIndices
         Assert.IsTrue(_indexedSet.Remove(0));
         Assert.IsFalse(_indexedSet.Remove(0));
         Assert.IsFalse(_indexedSet.Contains(0));
+    }
+
+    [TestMethod]
+    public void TryGetSingle_on_secondary_key()
+    {
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntProperty, 8, out TestData? data1));
+        Assert.IsNull(data1);
+
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntProperty, 10, out TestData? data2));
+        Assert.IsNull(data2);
+
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.IntProperty, 11, out TestData? data3));
+        Assert.IsNotNull(data3);
     }
 }

--- a/Akade.IndexedSet.Tests/UniqueIndices.cs
+++ b/Akade.IndexedSet.Tests/UniqueIndices.cs
@@ -81,4 +81,14 @@ public class UniqueIndices
         Assert.IsFalse(_indexedSet.Remove(0));
         Assert.IsFalse(_indexedSet.Contains(0));
     }
+
+    [TestMethod]
+    public void TryGetSingle_on_secondary_key()
+    {
+        Assert.IsFalse(_indexedSet.TryGetSingle(x => x.IntProperty, 8, out TestData? data1));
+        Assert.IsNull(data1);
+
+        Assert.IsTrue(_indexedSet.TryGetSingle(x => x.IntProperty, 10, out TestData? data2));
+        Assert.IsNotNull(data2);
+    }
 }

--- a/Akade.IndexedSet/Concurrency/ReaderWriterLockEx.cs
+++ b/Akade.IndexedSet/Concurrency/ReaderWriterLockEx.cs
@@ -14,8 +14,7 @@ internal sealed class ReaderWriterLockEx : IDisposable
 
     public void Dispose()
     {
-        _readerDisposable.Dispose();
-        _writerDisposable.Dispose();
+        _lock.Dispose();
     }
 
     public IDisposable EnterReadLock()

--- a/Akade.IndexedSet/IndexedSet.cs
+++ b/Akade.IndexedSet/IndexedSet.cs
@@ -137,6 +137,27 @@ public class IndexedSet<TElement>
     /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
     /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
     /// <param name="indexKey">The key within the index.</param>
+    /// <param name="element">The element if found, otherwise null.</param>
+    /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
+    [ReadAccess]
+    public bool TryGetSingle<TIndexKey>(
+        Func<TElement, IEnumerable<TIndexKey>> indexAccessor,
+        TIndexKey indexKey,
+        [NotNullWhen(true)] out TElement? element,
+        [CallerArgumentExpression("indexAccessor")] string? indexName = null)
+        where TIndexKey : notnull
+    {
+        TypedIndex<TElement, TIndexKey> typedIndex = GetIndex<TIndexKey>(indexName);
+        return typedIndex.TryGetSingle(indexKey, out element);
+    }
+
+    /// <summary>
+    /// Searches for an element via an index.
+    /// </summary>
+    /// <typeparam name="TIndexKey">The type of the index key</typeparam>
+    /// <param name="indexAccessor">Accessor for the indexed property. The expression as a string is used as an identifier for the index. Hence, the convention is to always use x as an identifier. 
+    /// Is passed to <paramref name="indexName"/> using <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <param name="indexKey">The key within the index.</param>
     /// <param name="indexName">The name of the index. Usually, you should not specify this as the expression in <paramref name="indexAccessor"/> is automatically passed by the compiler.</param>
     [ReadAccess]
     public TElement Single<TIndexKey>(
@@ -599,6 +620,18 @@ public class IndexedSet<TPrimaryKey, TElement> : IndexedSet<TElement>
     /// Short-hand for <see cref="Single(TPrimaryKey)"/>.
     /// </summary>
     public TElement this[TPrimaryKey key] => Single(key);
+
+    /// <summary>
+    /// Tries to get an element associated to the given primary key
+    /// </summary>
+    /// <param name="key">The primary key to obtain the item for</param>
+    /// <param name="result">The found element if the method returns true, otherwise null.</param>
+    /// <returns>True if an element is found, otherwise false.</returns>
+    [ReadAccess]
+    public bool TryGetSingle(TPrimaryKey key, [NotNullWhen(true)] out TElement? result)
+    {
+        return TryGetSingle(_primaryKeyAccessor, key, out result, _primaryKeyIndexName);
+    }
 
     /// <summary>
     /// Attempts to remove an item with the given primary key and returns true, if one was found and removed. Otherwise, false.

--- a/Akade.IndexedSet/PublicAPI.Shipped.txt
+++ b/Akade.IndexedSet/PublicAPI.Shipped.txt
@@ -23,6 +23,7 @@ Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Single<TIndexKey>(Sy
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Single<TIndexKey>(System.Func<TElement, TIndexKey>! indexAccessor, TIndexKey indexKey, string? indexName = null) -> TElement
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.StartsWith(System.Func<TElement, string!>! indexAccessor, System.ReadOnlySpan<char> prefix, string? indexName = null) -> System.Collections.Generic.IEnumerable<TElement>!
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.TryGetSingle<TIndexKey>(System.Func<TElement, TIndexKey>! indexAccessor, TIndexKey indexKey, out TElement? element, string? indexName = null) -> bool
+Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.TryGetSingle<TIndexKey>(System.Func<TElement, System.Collections.Generic.IEnumerable<TIndexKey>!>! indexAccessor, TIndexKey indexKey, out TElement? element, string? indexName = null) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update(System.Action<Akade.IndexedSet.IndexedSet<TElement>!>! updateFunc) -> void
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(System.Action<Akade.IndexedSet.IndexedSet<TElement>!, TState>! updateFunc, TState state) -> void
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Where<TIndexKey>(System.Func<TElement, System.Collections.Generic.IEnumerable<TIndexKey>!>! indexAccessor, TIndexKey contains, string? indexName = null) -> System.Collections.Generic.IEnumerable<TElement>!
@@ -61,6 +62,7 @@ Akade.IndexedSet.IndexedSet<TElement>.Single<TIndexKey>(System.Func<TElement, Sy
 Akade.IndexedSet.IndexedSet<TElement>.Single<TIndexKey>(System.Func<TElement, TIndexKey>! indexAccessor, TIndexKey indexKey, string? indexName = null) -> TElement
 Akade.IndexedSet.IndexedSet<TElement>.StartsWith(System.Func<TElement, string!>! indexAccessor, System.ReadOnlySpan<char> prefix, string? indexName = null) -> System.Collections.Generic.IEnumerable<TElement>!
 Akade.IndexedSet.IndexedSet<TElement>.TryGetSingle<TIndexKey>(System.Func<TElement, TIndexKey>! indexAccessor, TIndexKey indexKey, out TElement? element, string? indexName = null) -> bool
+Akade.IndexedSet.IndexedSet<TElement>.TryGetSingle<TIndexKey>(System.Func<TElement, System.Collections.Generic.IEnumerable<TIndexKey>!>! indexAccessor, TIndexKey indexKey, out TElement? element, string? indexName = null) -> bool
 Akade.IndexedSet.IndexedSet<TElement>.Update(TElement element, System.Action<TElement>! updateFunc) -> bool
 Akade.IndexedSet.IndexedSet<TElement>.Update(TElement element, System.Func<TElement, TElement>! updateFunc) -> bool
 Akade.IndexedSet.IndexedSet<TElement>.Update<TState>(TElement element, TState state, System.Action<TElement, TState>! updateFunc) -> bool

--- a/Akade.IndexedSet/PublicAPI.Unshipped.txt
+++ b/Akade.IndexedSet/PublicAPI.Unshipped.txt
@@ -5,4 +5,5 @@ Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(TElem
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update(TElement element, System.Func<TElement, TElement>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(TElement element, TState state, System.Func<TElement, TState, TElement>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Contains(TElement element) -> bool
-
+Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TPrimaryKey, TElement>.TryGetSingle(TPrimaryKey key, out TElement? result) -> bool
+Akade.IndexedSet.IndexedSet<TPrimaryKey, TElement>.TryGetSingle(TPrimaryKey key, out TElement? result) -> bool

--- a/generate_coverage.ps1
+++ b/generate_coverage.ps1
@@ -1,5 +1,5 @@
 Remove-Item Akade.IndexedSet.Tests\TestResults -Recurse
-dotnet test --collect "XPlat Code Coverage"
+dotnet test --collect "XPlat Code Coverage" -f net7.0
 $coverageReport = Get-Childitem -Path Akade.IndexedSet.Tests/TestResults -Include coverage.cobertura.xml -Recurse | select -expand FullName
 dotnet reportgenerator -reports:"$coverageReport" -targetdir:"coveragereport" -reporttypes:Html
 Invoke-Item coveragereport/index.html


### PR DESCRIPTION
- `TryGetSingle` for primary key based access
- `TryGetSingle` for indices with multiple keys per item. This is a ***soft* Breaking Change**. Soft means that if you've been using an `IEnumerable<T>` as a key itself, as opposed to being a collection of keys, you will need to explicitly specify the type arguments. As this use case is not intended and seems nonsensical, it should not break anyone.