### PR TITLE
[Fix] Fuzzy search for changed first char

### DIFF
--- a/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
@@ -9,7 +9,7 @@ namespace Akade.IndexedSet.Benchmarks;
 [SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net70)]
 public class FullTextIndexBenchmarks
 {
-    private record class Document(string Content);
+    public record class Document(string Content);
 
     private readonly IndexedSet<Document> _indexedSet;
     private readonly List<Document> _document;
@@ -18,7 +18,7 @@ public class FullTextIndexBenchmarks
     {
         Randomizer.Seed = new Random(42);
         _document = new Faker<Document>().CustomInstantiator(f => new Document(f.Rant.Review()))
-                                         .Generate(5000);
+                                         .Generate(1000);
 
         _indexedSet = _document.ToIndexedSet()
                                .WithFullTextIndex(x => x.Content)
@@ -28,45 +28,45 @@ public class FullTextIndexBenchmarks
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Contains")]
-    public int Contains_Linq()
+    public Document[] Contains_Linq()
     {
-        return _document.Count(x => x.Content.Contains("excellent"));
+        return _document.Where(x => x.Content.Contains("cheeseburger")).ToArray();
     }
 
     [Benchmark]
     [BenchmarkCategory("Contains")]
-    public int Contains_IndexedSet()
+    public Document[] Contains_IndexedSet()
     {
-        return _indexedSet.Contains(x => x.Content, "excellent").Count();
+        return _indexedSet.Contains(x => x.Content, "cheeseburger").ToArray();
     }
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Fuzzy Contains")]
-    public int FuzzyContains_Linq()
+    public Document[] FuzzyContains_Linq()
     {
-        return _document.Count(x =>
+        return _document.Where(x =>
         {
-            if (Fastenshtein.Levenshtein.Distance("excellent", x.Content) < 2)
+            if (Fastenshtein.Levenshtein.Distance("cheeseburger", x.Content) < 2)
             {
                 return true;
             }
 
             for (int i = 0; i < x.Content.Length - 9; i++)
             {
-                if (Fastenshtein.Levenshtein.Distance("excellent", x.Content.Substring(i, 9)) < 2)
+                if (Fastenshtein.Levenshtein.Distance("cheeseburger", x.Content.Substring(i, 9)) < 2)
                 {
                     return true;
                 }
             }
 
             return false;
-        });
+        }).ToArray();
     }
 
     [Benchmark]
     [BenchmarkCategory("Fuzzy Contains")]
-    public int FuzzyContains_IndexedSet()
+    public Document[] FuzzyContains_IndexedSet()
     {
-        return _indexedSet.FuzzyContains(x => x.Content, "excellent", 2).Count();
+        return _indexedSet.FuzzyContains(x => x.Content, "cheeseburger", 2).ToArray();
     }
 }

--- a/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/FullTextIndexBenchmarks.cs
@@ -18,7 +18,7 @@ public class FullTextIndexBenchmarks
     {
         Randomizer.Seed = new Random(42);
         _document = new Faker<Document>().CustomInstantiator(f => new Document(f.Rant.Review()))
-                                         .Generate(1000);
+                                         .Generate(5000);
 
         _indexedSet = _document.ToIndexedSet()
                                .WithFullTextIndex(x => x.Content)

--- a/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
@@ -15,7 +15,7 @@ public class PrefixIndexBenchmarks
     public PrefixIndexBenchmarks()
     {
         Randomizer.Seed = new Random(42);
-        _persons = Enumerable.Range(0, 1000)
+        _persons = Enumerable.Range(0, 5000)
                              .Select(_ => new Person())
                              .ToList();
 

--- a/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
+++ b/Akade.IndexedSet.Benchmarks/PrefixIndexBenchmarks.cs
@@ -15,7 +15,7 @@ public class PrefixIndexBenchmarks
     public PrefixIndexBenchmarks()
     {
         Randomizer.Seed = new Random(42);
-        _persons = Enumerable.Range(0, 5000)
+        _persons = Enumerable.Range(0, 1000)
                              .Select(_ => new Person())
                              .ToList();
 
@@ -26,29 +26,29 @@ public class PrefixIndexBenchmarks
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("StartsWith")]
-    public int StartsWith_Linq()
+    public Person[] StartsWith_Linq()
     {
-        return _persons.Count(x => x.FullName.StartsWith("Peter", StringComparison.Ordinal));
+        return _persons.Where(x => x.FullName.StartsWith("Tiffany", StringComparison.Ordinal)).ToArray();
     }
 
     [Benchmark]
     [BenchmarkCategory("StartsWith")]
-    public int StartsWith_IndexedSet()
+    public Person[] StartsWith_IndexedSet()
     {
-        return _indexedSet.StartsWith(x => x.FullName, "Peter").Count();
+        return _indexedSet.StartsWith(x => x.FullName, "Tiffany").ToArray();
     }
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Fuzzy StartsWith")]
-    public int FuzzyStartsWith_Linq()
+    public Person[] FuzzyStartsWith_Linq()
     {
-        return _persons.Count(x => Fastenshtein.Levenshtein.Distance(x.FullName[..5], "Peter") <= 2);
+        return _persons.Where(x => Fastenshtein.Levenshtein.Distance(x.FullName[..Math.Min(7, x.FullName.Length)], "Tiffany") <= 2).ToArray();
     }
 
     [Benchmark]
     [BenchmarkCategory("Fuzzy StartsWith")]
-    public int FuzzyStartsWith_IndexedSet()
+    public Person[] FuzzyStartsWith_IndexedSet()
     {
-        return _indexedSet.FuzzyStartsWith(x => x.FullName, "Peter", 2).Count();
+        return _indexedSet.FuzzyStartsWith(x => x.FullName, "Tiffany", 2).ToArray();
     }
 }

--- a/Akade.IndexedSet.Benchmarks/Program.cs
+++ b/Akade.IndexedSet.Benchmarks/Program.cs
@@ -1,17 +1,4 @@
-﻿// See https://aka.ms/new-console-template for more information
-
-//using Akade.IndexedSet.Benchmarks;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using System.Reflection;
 
 _ = BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
-//FullTextIndexBenchmarks test = new();
-//GC.Collect();
-//Console.WriteLine("Press to start");
-//Console.ReadKey();
-//Console.WriteLine("started");
-
-//for (int i = 0; i < 1000; i++)
-//{
-//    _ = test.FuzzyContains_IndexedSet();
-//}

--- a/Akade.IndexedSet.Benchmarks/Program.cs
+++ b/Akade.IndexedSet.Benchmarks/Program.cs
@@ -5,13 +5,13 @@ using BenchmarkDotNet.Running;
 using System.Reflection;
 
 _ = BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
-//PrefixIndexBenchmarks test = new();
+//FullTextIndexBenchmarks test = new();
 //GC.Collect();
 //Console.WriteLine("Press to start");
 //Console.ReadKey();
 //Console.WriteLine("started");
 
-//for (int i = 0; i < 10000; i++)
+//for (int i = 0; i < 1000; i++)
 //{
-//    _ = test.StartsWith_IndexedSet();
+//    _ = test.FuzzyContains_IndexedSet();
 //}

--- a/Akade.IndexedSet.Benchmarks/Program.cs
+++ b/Akade.IndexedSet.Benchmarks/Program.cs
@@ -1,5 +1,17 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
+//using Akade.IndexedSet.Benchmarks;
 using BenchmarkDotNet.Running;
 using System.Reflection;
+
 _ = BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+//PrefixIndexBenchmarks test = new();
+//GC.Collect();
+//Console.WriteLine("Press to start");
+//Console.ReadKey();
+//Console.WriteLine("started");
+
+//for (int i = 0; i < 10000; i++)
+//{
+//    _ = test.StartsWith_IndexedSet();
+//}

--- a/Akade.IndexedSet.Tests/DataStructures/SuffixTrieTests.cs
+++ b/Akade.IndexedSet.Tests/DataStructures/SuffixTrieTests.cs
@@ -99,6 +99,14 @@ public class SuffixTrieTests
 
     [TestMethod]
 
+    public void inexact_fuzzy_search_and_single_result()
+    {
+        IEnumerable<string> result = _trie.FuzzySearch("Pangolin", 2, false);
+        CollectionAssert.AreEquivalent(new[] { "Pangolin" }, result.ToArray());
+    }
+
+    [TestMethod]
+
     public void inexact_fuzzy_search_and_multiple_result()
     {
         IEnumerable<string> result = _trie.FuzzySearch("Pan", 2, false);
@@ -112,6 +120,12 @@ public class SuffixTrieTests
         Assert.IsFalse(result.Any());
     }
 
+    [TestMethod]
+    public void inexact_fuzzy_search_and_multiple_result_with_first_character_changed()
+    {
+        IEnumerable<string> result = _trie.FuzzySearch("Zan", 1, false);
+        CollectionAssert.AreEquivalent(new[] { "Panther", "Pangolin", "Tarantula" }, result.ToArray());
+    }
 
     // https://murilo.wordpress.com/2011/02/01/fast-and-easy-levenshtein-distance-using-a-trie-in-c/
     private static bool AddToStringTrie(SuffixTrie<string> stringTrie, string value)

--- a/Akade.IndexedSet.Tests/DataStructures/TrieTests.cs
+++ b/Akade.IndexedSet.Tests/DataStructures/TrieTests.cs
@@ -6,6 +6,8 @@ namespace Akade.IndexedSet.Tests.DataStructures;
 [TestClass]
 public class TrieTests
 {
+    private readonly Trie<string> _trie = GetAnimalTrie();
+
     private static Trie<string> GetAnimalTrie()
     {
         Trie<string> trie = new();
@@ -22,13 +24,11 @@ public class TrieTests
     [TestMethod]
     public void querying_common_prefixes_return_correct_elements()
     {
-        Trie<string> trie = GetAnimalTrie();
-
-        CollectionAssert.AreEquivalent(new string[] { "Tiger", "Tarantula" }, trie.GetAll("T").ToArray());
-        CollectionAssert.AreEquivalent(new string[] { "Penguin", "Panther", "Pangolin", "Parrot" }, trie.GetAll("P").ToArray());
-        CollectionAssert.AreEquivalent(new string[] { "Panther", "Pangolin", "Parrot" }, trie.GetAll("Pa").ToArray());
-        CollectionAssert.AreEquivalent(new string[] { "Panther", "Pangolin" }, trie.GetAll("Pan").ToArray());
-        CollectionAssert.AreEquivalent(new string[] { "Panther" }, trie.GetAll("Pant").ToArray());
+        CollectionAssert.AreEquivalent(new string[] { "Tiger", "Tarantula" }, _trie.GetAll("T").ToArray());
+        CollectionAssert.AreEquivalent(new string[] { "Penguin", "Panther", "Pangolin", "Parrot" }, _trie.GetAll("P").ToArray());
+        CollectionAssert.AreEquivalent(new string[] { "Panther", "Pangolin", "Parrot" }, _trie.GetAll("Pa").ToArray());
+        CollectionAssert.AreEquivalent(new string[] { "Panther", "Pangolin" }, _trie.GetAll("Pan").ToArray());
+        CollectionAssert.AreEquivalent(new string[] { "Panther" }, _trie.GetAll("Pant").ToArray());
     }
 
     [TestMethod]
@@ -71,38 +71,44 @@ public class TrieTests
     [TestMethod]
     public void exact_fuzzy_search_with_single_result()
     {
-        Trie<string> trie = GetAnimalTrie();
-
-        IEnumerable<string> result = trie.FuzzySearch("Panter", 1, true);
+        IEnumerable<string> result = _trie.FuzzySearch("Panter", 1, true);
         Assert.AreEqual("Panther", result.Single());
     }
 
     [TestMethod]
     public void exact_fuzzy_search_without_results()
     {
-        Trie<string> trie = GetAnimalTrie();
-
-        IEnumerable<string> result = trie.FuzzySearch("Panner", 1, true);
+        IEnumerable<string> result = _trie.FuzzySearch("Panner", 1, true);
         Assert.IsFalse(result.Any());
+    }
+
+    [TestMethod]
+
+    public void inexact_fuzzy_search_and_single_result()
+    {
+        IEnumerable<string> result = _trie.FuzzySearch("Pangolin", 2, false);
+        CollectionAssert.AreEquivalent(new[] { "Pangolin" }, result.ToArray());
     }
 
     [TestMethod]
     public void inexact_fuzzy_search_and_multiple_result()
     {
-        Trie<string> trie = GetAnimalTrie();
-
-        IEnumerable<string> result = trie.FuzzySearch("Pan", 2, false);
-
-        CollectionAssert.AreEquivalent(new[] { "Penguin", "Panther", "Pangolin", "Parrot" }, result.ToArray());
+        IEnumerable<string> result = _trie.FuzzySearch("Pan", 2, false);
+        CollectionAssert.AreEquivalent(new[] { "Penguin", "Panther", "Pangolin", "Parrot", "Tarantula" }, result.ToArray());
     }
 
     [TestMethod]
     public void inexact_fuzzy_search_without_result()
     {
-        Trie<string> trie = GetAnimalTrie();
-
-        IEnumerable<string> result = trie.FuzzySearch("Non", 1, false);
+        IEnumerable<string> result = _trie.FuzzySearch("Non", 1, false);
         Assert.IsFalse(result.Any());
+    }
+
+    [TestMethod]
+    public void inexact_fuzzy_search_and_multiple_result_with_first_character_changed()
+    {
+        IEnumerable<string> result = _trie.FuzzySearch("Zan", 1, false);
+        CollectionAssert.AreEquivalent(new[] { "Panther", "Pangolin" }, result.ToArray());
     }
 
     private static bool AddToStringTrie(Trie<string> stringTrie, string value)

--- a/Akade.IndexedSet/DataStructures/Trie.cs
+++ b/Akade.IndexedSet/DataStructures/Trie.cs
@@ -92,7 +92,10 @@ internal class Trie<TElement>
             {
                 if (currentNode._elements is not null)
                 {
-                    results.EnqueueRange(currentNode._elements, currentRow[^1]);
+                    foreach (TElement element in currentNode._elements)
+                    {
+                        results.Enqueue(element, currentRow[^1]);
+                    }
                 }
             }
             else
@@ -124,7 +127,10 @@ internal class Trie<TElement>
     {
         if (currentNode._elements is not null)
         {
-            results.EnqueueRange(currentNode._elements, distance);
+            foreach (TElement element in currentNode._elements)
+            {
+                results.Enqueue(element, distance);
+            }
         }
         if (currentNode._children is not null)
         {

--- a/Akade.IndexedSet/DataStructures/Trie.cs
+++ b/Akade.IndexedSet/DataStructures/Trie.cs
@@ -164,7 +164,7 @@ internal class Trie<TElement>
 
     private class TrieNode
     {
-        internal SortedDictionary<char, TrieNode>? _children;
+        internal Dictionary<char, TrieNode>? _children;
         internal HashSet<TElement>? _elements;
 
         internal bool Add(ReadOnlySpan<char> key, TElement element)

--- a/Akade.IndexedSet/DataStructures/Trie.cs
+++ b/Akade.IndexedSet/DataStructures/Trie.cs
@@ -60,17 +60,14 @@ internal class Trie<TElement>
 
         PriorityQueue<TrieNode, int> results = new();
 
-        for (int i = 0; i < wordLength; i++)
+        foreach (KeyValuePair<char, TrieNode> child in _root.GetLocalChildren())
         {
-            if (_root.TryGetChild(word[i], out TrieNode? startNode))
-            {
-                FuzzySearchInternal(startNode, word[i], currentRow, word, results, maxDistance, exactMatches);
-            }
+            FuzzySearchInternal(child.Value, child.Key, currentRow, word, results, maxDistance, exactMatches);
         }
 
         return exactMatches
             ? results.DequeueAsIEnumerable().SelectMany(node => node.GetLocalElements())
-            : results.DequeueAsIEnumerable().SelectMany(node => node.GetAllChildren().SelectMany(n => n.GetLocalElements()));
+            : results.DequeueAsIEnumerable().SelectMany(node => node.GetLocalElements().Concat(node.GetAllChildren().SelectMany(n => n.GetLocalElements())));
     }
 
     private void FuzzySearchInternal(TrieNode currentNode, char ch, int[] lastRow, ReadOnlySpan<char> word, PriorityQueue<TrieNode, int> results, int maxDistance, bool exploreSubTrees)

--- a/Akade.IndexedSet/DataStructures/Trie.cs
+++ b/Akade.IndexedSet/DataStructures/Trie.cs
@@ -1,4 +1,5 @@
 ﻿using Akade.IndexedSet.Extensions;
+using Akade.IndexedSet.Utils;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Akade.IndexedSet.DataStructures;
@@ -20,7 +21,7 @@ internal class Trie<TElement>
     public IEnumerable<TElement> Get(ReadOnlySpan<char> key)
     {
         TrieNode? matchingNode = _root.Find(key);
-        return matchingNode is null ? Enumerable.Empty<TElement>() : matchingNode.GetLocalElements();
+        return matchingNode is null || matchingNode._elements is null ? Enumerable.Empty<TElement>() : matchingNode._elements;
     }
 
     public bool Contains(ReadOnlySpan<char> key, TElement element)
@@ -37,42 +38,39 @@ internal class Trie<TElement>
             return Enumerable.Empty<TElement>();
         }
 
-        IEnumerable<TElement> result = matchingNode.GetLocalElements();
-
-        foreach (TrieNode node in matchingNode.GetAllChildren())
-        {
-            result = result.Concat(node.GetLocalElements());
-        }
-
+        List<TElement> result = new();
+        AddRecursivlyToResult(matchingNode, result);
         return result;
     }
 
     public IEnumerable<TElement> FuzzySearch(ReadOnlySpan<char> word, int maxDistance, bool exactMatches)
     {
-        int wordLength = word.Length;
+        int rowLength = word.Length + 1;
 
-        int[] currentRow = new int[wordLength + 1];
+        Span<int> currentRow = rowLength < LevenshteinDistance.MaxStackAlloc ? stackalloc int[rowLength] : new int[rowLength];
 
         for (int i = 0; i < currentRow.Length; i++)
         {
             currentRow[i] = i;
         }
 
-        PriorityQueue<TrieNode, int> results = new();
+        PriorityQueue<TElement, int> results = new();
 
-        foreach (KeyValuePair<char, TrieNode> child in _root.GetLocalChildren())
+        if (_root._children is not null)
         {
-            FuzzySearchInternal(child.Value, child.Key, currentRow, word, results, maxDistance, exactMatches);
+            foreach (KeyValuePair<char, TrieNode> child in _root._children)
+            {
+                FuzzySearchInternal(child.Value, child.Key, currentRow, word, results, maxDistance, exactMatches);
+            }
         }
 
-        return exactMatches
-            ? results.DequeueAsIEnumerable().SelectMany(node => node.GetLocalElements())
-            : results.DequeueAsIEnumerable().SelectMany(node => node.GetLocalElements().Concat(node.GetAllChildren().SelectMany(n => n.GetLocalElements())));
+        return results.DequeueAsIEnumerable();
     }
 
-    private void FuzzySearchInternal(TrieNode currentNode, char ch, int[] lastRow, ReadOnlySpan<char> word, PriorityQueue<TrieNode, int> results, int maxDistance, bool exploreSubTrees)
+    private void FuzzySearchInternal(TrieNode currentNode, char ch, ReadOnlySpan<int> lastRow, ReadOnlySpan<char> word, PriorityQueue<TElement, int> results, int maxDistance, bool exactMatches)
     {
-        int[] currentRow = new int[lastRow.Length];
+
+        Span<int> currentRow = lastRow.Length < LevenshteinDistance.MaxStackAlloc ? stackalloc int[lastRow.Length] : new int[lastRow.Length];
         currentRow[0] = lastRow[0] + 1;
 
         int minDistance = currentRow[0];
@@ -89,20 +87,66 @@ internal class Trie<TElement>
 
         if (currentRow[^1] <= maxDistance)
         {
-            results.Enqueue(currentNode, currentRow[^1]);
+
+            if (exactMatches)
+            {
+                if (currentNode._elements is not null)
+                {
+                    results.EnqueueRange(currentNode._elements, currentRow[^1]);
+                }
+            }
+            else
+            {
+                AddRecursivlyToResult(currentNode, results, currentRow[^1]);
+            }
+
             found = true;
         }
 
-        if (!exploreSubTrees && found)
+        if (!exactMatches && found)
         {
             return;
         }
 
         if (minDistance <= maxDistance)
         {
-            foreach (KeyValuePair<char, TrieNode> child in currentNode.GetLocalChildren())
+            if (currentNode._children is not null)
             {
-                FuzzySearchInternal(child.Value, child.Key, currentRow, word, results, maxDistance, exploreSubTrees);
+                foreach (KeyValuePair<char, TrieNode> child in currentNode._children)
+                {
+                    FuzzySearchInternal(child.Value, child.Key, currentRow, word, results, maxDistance, exactMatches);
+                }
+            }
+        }
+    }
+
+    private static void AddRecursivlyToResult(Trie<TElement>.TrieNode currentNode, PriorityQueue<TElement, int> results, int distance)
+    {
+        if (currentNode._elements is not null)
+        {
+            results.EnqueueRange(currentNode._elements, distance);
+        }
+        if (currentNode._children is not null)
+        {
+            foreach ((_, Trie<TElement>.TrieNode child) in currentNode._children)
+            {
+                AddRecursivlyToResult(child, results, distance);
+            }
+        }
+    }
+
+    private static void AddRecursivlyToResult(Trie<TElement>.TrieNode currentNode, List<TElement> results)
+    {
+        if (currentNode._elements is not null)
+        {
+            results.AddRange(currentNode._elements);
+        }
+
+        if (currentNode._children is not null)
+        {
+            foreach ((_, Trie<TElement>.TrieNode child) in currentNode._children)
+            {
+                AddRecursivlyToResult(child, results);
             }
         }
     }
@@ -114,8 +158,8 @@ internal class Trie<TElement>
 
     private class TrieNode
     {
-        private SortedDictionary<char, TrieNode>? _children;
-        private HashSet<TElement>? _elements;
+        internal SortedDictionary<char, TrieNode>? _children;
+        internal HashSet<TElement>? _elements;
 
         internal bool Add(ReadOnlySpan<char> key, TElement element)
         {
@@ -148,34 +192,6 @@ internal class Trie<TElement>
             }
 
             return null;
-        }
-
-        internal IEnumerable<TrieNode> GetAllChildren()
-        {
-            if (_children is null)
-            {
-                yield break;
-            }
-
-            foreach (TrieNode node in _children.Values)
-            {
-                yield return node;
-
-                foreach (TrieNode child in node.GetAllChildren())
-                {
-                    yield return child;
-                }
-            }
-        }
-
-        internal IEnumerable<KeyValuePair<char, TrieNode>> GetLocalChildren()
-        {
-            return _children ?? Enumerable.Empty<KeyValuePair<char, TrieNode>>();
-        }
-
-        internal IEnumerable<TElement> GetLocalElements()
-        {
-            return _elements ?? Enumerable.Empty<TElement>();
         }
 
         internal bool Remove(ReadOnlySpan<char> key, TElement element)

--- a/Akade.IndexedSet/Indices/FullTextIndex.cs
+++ b/Akade.IndexedSet/Indices/FullTextIndex.cs
@@ -84,12 +84,12 @@ internal class FullTextIndex<TElement> : TypedIndex<TElement, string>
 
     internal override IEnumerable<TElement> FuzzyContains(ReadOnlySpan<char> indexKey, int maxDistance)
     {
-        return _suffixTrie.FuzzySearch(indexKey, maxDistance, false).Distinct();
+        return _suffixTrie.FuzzySearch(indexKey, maxDistance, false);
     }
 
     internal override IEnumerable<TElement> Contains(ReadOnlySpan<char> indexKey)
     {
-        return _suffixTrie.GetAll(indexKey).Distinct();
+        return _suffixTrie.GetAll(indexKey);
     }
 
     public override void Clear()

--- a/Akade.IndexedSet/Utils/LevenshteinDistance.cs
+++ b/Akade.IndexedSet/Utils/LevenshteinDistance.cs
@@ -2,13 +2,15 @@
 
 internal static class LevenshteinDistance
 {
+    public const int MaxStackAlloc = 256;
+
     /// <summary>
     /// Returns true if the strings have a levenshein distance smaller than <paramref name="maxDistance"/>.
     /// Does not calculate the entire distance if the minimum distance is already bigger.
     /// </summary>
     public static bool FuzzyMatch(ReadOnlySpan<char> a, ReadOnlySpan<char> b, int maxDistance)
     {
-        int wordLength = a.Length;
+        int rowLength = a.Length + 1;
 
         if (a.Length == 0 && b.Length == 0)
         {
@@ -20,7 +22,8 @@ internal static class LevenshteinDistance
             return false;
         }
 
-        int[] currentRow = new int[wordLength + 1];
+        Span<int> lastRow = rowLength < MaxStackAlloc ? stackalloc int[rowLength] : new int[rowLength];
+        Span<int> currentRow = rowLength < MaxStackAlloc ? stackalloc int[rowLength] : new int[rowLength];
         for (int i = 0; i < currentRow.Length; i++)
         {
             currentRow[i] = i;
@@ -28,8 +31,10 @@ internal static class LevenshteinDistance
 
         for (int j = 0; j < b.Length; j++)
         {
-            int[] lastRow = currentRow;
-            currentRow = new int[wordLength + 1];
+            Span<int> tmp = lastRow;
+            lastRow = currentRow;
+            currentRow = tmp;
+
             currentRow[0] = lastRow[0] + 1;
 
             int minDistance = currentRow[0];

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -3,12 +3,12 @@ Benchmarks measured on 27.07.2022:
 
 ## Environment
 ``` ini
-BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.755)
+BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1928/22H2/2022Update/SunValley2)
 AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK=7.0.100
-  [Host]   : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-  .NET 6.0 : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
-  .NET 7.0 : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+.NET SDK=7.0.304
+  [Host]   : .NET 7.0.7 (7.0.723.27404), X64 RyuJIT AVX2
+  .NET 6.0 : .NET 6.0.18 (6.0.1823.26907), X64 RyuJIT AVX2
+  .NET 7.0 : .NET 7.0.7 (7.0.723.27404), X64 RyuJIT AVX2
 ```
 
 All benchmarks are currenlty using *1k elements*. Benchmarks showing the scaling is on the roadmap - expect IndexedSet to scale much
@@ -18,15 +18,15 @@ the benchmarks are run against both .NET 6 and 7.
 ## Unique-Index
 |                       Method |  Runtime |         Mean |       Error |      StdDev | Ratio |   Gen0 | Code Size | Allocated | Alloc Ratio |
 |----------------------------- |--------- |-------------:|------------:|------------:|------:|-------:|----------:|----------:|------------:|
-|                  Unqiue_Linq | .NET 6.0 | 156,714.6 ns |   341.01 ns |   284.76 ns | 1.000 | 0.7324 |     753 B |   12800 B |        1.00 |
-|            Unique_Dictionary | .NET 6.0 |     473.6 ns |     1.47 ns |     1.38 ns | 0.003 |      - |     681 B |         - |        0.00 |
-| Unique_IndexedSet_PrimaryKey | .NET 6.0 |   1,692.7 ns |     6.08 ns |     5.69 ns | 0.011 |      - |     512 B |         - |        0.00 |
-|     Unique_IndexedSet_Single | .NET 6.0 |   1,538.3 ns |    10.43 ns |     9.24 ns | 0.010 |      - |   1,224 B |         - |        0.00 |
+|                  Unqiue_Linq | .NET 6.0 | 162,090.0 ns |   409.27 ns |   319.53 ns | 1.000 | 0.7324 |     753 B |   12800 B |        1.00 |
+|            Unique_Dictionary | .NET 6.0 |     468.1 ns |     0.72 ns |     0.60 ns | 0.003 |      - |     681 B |         - |        0.00 |
+| Unique_IndexedSet_PrimaryKey | .NET 6.0 |   1,702.4 ns |     5.46 ns |     5.10 ns | 0.011 |      - |     512 B |         - |        0.00 |
+|     Unique_IndexedSet_Single | .NET 6.0 |   1,573.2 ns |     6.85 ns |     6.40 ns | 0.010 |      - |   1,224 B |         - |        0.00 |
 |                              |          |              |             |             |       |        |           |           |             |
-|                  Unqiue_Linq | .NET 7.0 | 158,745.0 ns | 2,950.18 ns | 2,615.26 ns | 1.000 | 0.7324 |     696 B |   12800 B |        1.00 |
-|            Unique_Dictionary | .NET 7.0 |     397.4 ns |     0.64 ns |     0.60 ns | 0.003 |      - |     590 B |         - |        0.00 |
-| Unique_IndexedSet_PrimaryKey | .NET 7.0 |   1,379.7 ns |     3.11 ns |     2.59 ns | 0.009 |      - |   1,084 B |         - |        0.00 |
-|     Unique_IndexedSet_Single | .NET 7.0 |   1,393.3 ns |     2.46 ns |     2.18 ns | 0.009 |      - |   1,145 B |         - |        0.00 |
+|                  Unqiue_Linq | .NET 7.0 | 160,159.7 ns | 2,988.17 ns | 2,648.94 ns | 1.000 | 0.7324 |     696 B |   12800 B |        1.00 |
+|            Unique_Dictionary | .NET 7.0 |     404.1 ns |     0.41 ns |     0.32 ns | 0.003 |      - |     590 B |         - |        0.00 |
+| Unique_IndexedSet_PrimaryKey | .NET 7.0 |   1,394.0 ns |     2.89 ns |     2.70 ns | 0.009 |      - |   1,084 B |         - |        0.00 |
+|     Unique_IndexedSet_Single | .NET 7.0 |   1,414.8 ns |     3.26 ns |     2.73 ns | 0.009 |      - |   1,145 B |         - |        0.00 |
 
 > ℹ️ Note that manually maintaining a dictionary is *currently* faster but only if the executing class has direct access
 > to the dictionary. Ideas to bring it on par are being explored for scenarios with very tight loops around dictionary lookup.
@@ -34,101 +34,101 @@ the benchmarks are run against both .NET 6 and 7.
 ## MultiValue-Index
 |                Method |  Runtime |     Mean |    Error |   StdDev | Ratio | Code Size |   Gen0 | Allocated | Alloc Ratio |
 |---------------------- |--------- |---------:|---------:|---------:|------:|----------:|-------:|----------:|------------:|
-|       MultiValue_Linq | .NET 6.0 | 64.40 μs | 0.476 μs | 0.445 μs |  1.00 |   2,575 B |      - |    1680 B |        1.00 |
-|     Multivalue_Lookup | .NET 6.0 | 12.53 μs | 0.151 μs | 0.141 μs |  0.19 |   1,768 B | 0.0153 |     360 B |        0.21 |
-| Multivalue_IndexedSet | .NET 6.0 | 12.78 μs | 0.068 μs | 0.063 μs |  0.20 |   2,729 B | 0.0153 |     360 B |        0.21 |
+|       MultiValue_Linq | .NET 6.0 | 62.54 μs | 0.383 μs | 0.340 μs |  1.00 |   2,575 B |      - |    1680 B |        1.00 |
+|     Multivalue_Lookup | .NET 6.0 | 12.24 μs | 0.078 μs | 0.069 μs |  0.20 |   1,768 B | 0.0153 |     360 B |        0.21 |
+| Multivalue_IndexedSet | .NET 6.0 | 12.79 μs | 0.036 μs | 0.030 μs |  0.20 |   2,729 B | 0.0153 |     360 B |        0.21 |
 |                       |          |          |          |          |       |           |        |           |             |
-|       MultiValue_Linq | .NET 7.0 | 56.89 μs | 1.024 μs | 0.799 μs |  1.00 |   2,569 B | 0.0610 |    1680 B |        1.00 |
-|     Multivalue_Lookup | .NET 7.0 | 11.71 μs | 0.023 μs | 0.022 μs |  0.21 |   1,746 B | 0.0153 |     360 B |        0.21 |
-| Multivalue_IndexedSet | .NET 7.0 | 12.86 μs | 0.106 μs | 0.088 μs |  0.23 |   2,638 B | 0.0153 |     360 B |        0.21 |
+|       MultiValue_Linq | .NET 7.0 | 57.03 μs | 0.373 μs | 0.291 μs |  1.00 |   2,569 B | 0.0610 |    1680 B |        1.00 |
+|     Multivalue_Lookup | .NET 7.0 | 23.25 μs | 0.158 μs | 0.148 μs |  0.41 |   1,746 B |      - |     360 B |        0.21 |
+| Multivalue_IndexedSet | .NET 7.0 | 13.12 μs | 0.059 μs | 0.055 μs |  0.23 |   2,638 B | 0.0153 |     360 B |        0.21 |
 
 > ℹ️ Solution is on par with manually using LINQ's lookup (i.e. `.ToLookup()`)
 
 ## Range-Index
-|              Method |  Runtime |         Mean |        Error |       StdDev |       Median | Ratio |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
-|-------------------- |--------- |-------------:|-------------:|-------------:|-------------:|------:|-------:|-------:|----------:|------------:|
-|       LessThan_Linq | .NET 6.0 | 16,878.19 ns |    65.965 ns |    58.477 ns | 16,887.68 ns |  1.00 |      - |      - |     160 B |        1.00 |
-| LessThan_IndexedSet | .NET 6.0 |  3,637.28 ns |     3.884 ns |     3.243 ns |  3,638.40 ns |  0.22 | 0.0038 |      - |      72 B |        0.45 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|       LessThan_Linq | .NET 7.0 | 18,117.09 ns |    67.318 ns |    62.970 ns | 18,120.34 ns |  1.00 |      - |      - |     160 B |        1.00 |
-| LessThan_IndexedSet | .NET 7.0 |  3,858.55 ns |     3.655 ns |     3.240 ns |  3,858.11 ns |  0.21 |      - |      - |      72 B |        0.45 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|            Min_Linq | .NET 6.0 | 79,119.22 ns | 1,245.002 ns | 1,164.576 ns | 79,051.43 ns | 1.000 |      - |      - |      40 B |        1.00 |
-|      Min_IndexedSet | .NET 6.0 |     10.28 ns |     0.025 ns |     0.024 ns |     10.28 ns | 0.000 |      - |      - |         - |        0.00 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|            Min_Linq | .NET 7.0 | 67,645.12 ns |   755.328 ns |   589.710 ns | 67,805.86 ns | 1.000 |      - |      - |      40 B |        1.00 |
-|      Min_IndexedSet | .NET 7.0 |     10.05 ns |     0.014 ns |     0.012 ns |     10.05 ns | 0.000 |      - |      - |         - |        0.00 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|         Paging_Linq | .NET 6.0 | 74,292.36 ns | 1,203.178 ns | 1,125.454 ns | 74,021.94 ns | 1.000 | 9.5215 | 2.3193 |  160352 B |       1.000 |
-|   Paging_IndexedSet | .NET 6.0 |    183.20 ns |     0.814 ns |     0.721 ns |    183.05 ns | 0.002 | 0.0277 |      - |     464 B |       0.003 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|         Paging_Linq | .NET 7.0 | 74,679.34 ns | 1,492.779 ns | 1,941.034 ns | 75,474.67 ns | 1.000 | 9.5215 | 2.3193 |  160352 B |       1.000 |
-|   Paging_IndexedSet | .NET 7.0 |    174.12 ns |     0.902 ns |     0.753 ns |    174.16 ns | 0.002 | 0.0277 |      - |     464 B |       0.003 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|          Range_Linq | .NET 6.0 | 20,597.43 ns |   398.112 ns |   473.924 ns | 20,733.38 ns |  1.00 |      - |      - |     168 B |        1.00 |
-|    Range_IndexedSet | .NET 6.0 |  2,829.46 ns |     2.671 ns |     2.498 ns |  2,829.46 ns |  0.14 | 0.0038 |      - |      72 B |        0.43 |
-|                     |          |              |              |              |              |       |        |        |           |             |
-|          Range_Linq | .NET 7.0 | 26,647.35 ns |   751.672 ns | 2,216.321 ns | 24,949.59 ns |  1.00 |      - |      - |     160 B |        1.00 |
-|    Range_IndexedSet | .NET 7.0 |  3,006.22 ns |     7.875 ns |     7.366 ns |  3,009.67 ns |  0.11 | 0.0038 |      - |      72 B |        0.45 |
+|              Method |  Runtime |         Mean |        Error |       StdDev | Ratio |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|-------------------- |--------- |-------------:|-------------:|-------------:|------:|-------:|-------:|----------:|------------:|
+|       LessThan_Linq | .NET 6.0 | 17,085.96 ns |    42.395 ns |    35.402 ns |  1.00 |      - |      - |     160 B |        1.00 |
+| LessThan_IndexedSet | .NET 6.0 |  3,904.46 ns |     7.180 ns |     6.365 ns |  0.23 |      - |      - |      72 B |        0.45 |
+|                     |          |              |              |              |       |        |        |           |             |
+|       LessThan_Linq | .NET 7.0 | 18,436.02 ns |    77.562 ns |    72.552 ns |  1.00 |      - |      - |     160 B |        1.00 |
+| LessThan_IndexedSet | .NET 7.0 |  3,468.00 ns |     4.656 ns |     3.888 ns |  0.19 | 0.0038 |      - |      72 B |        0.45 |
+|                     |          |              |              |              |       |        |        |           |             |
+|            Min_Linq | .NET 6.0 | 75,491.15 ns | 1,115.048 ns | 1,043.016 ns | 1.000 |      - |      - |      40 B |        1.00 |
+|      Min_IndexedSet | .NET 6.0 |     10.13 ns |     0.043 ns |     0.041 ns | 0.000 |      - |      - |         - |        0.00 |
+|                     |          |              |              |              |       |        |        |           |             |
+|            Min_Linq | .NET 7.0 | 69,477.64 ns | 1,000.359 ns |   935.736 ns | 1.000 |      - |      - |      40 B |        1.00 |
+|      Min_IndexedSet | .NET 7.0 |     10.40 ns |     0.055 ns |     0.046 ns | 0.000 |      - |      - |         - |        0.00 |
+|                     |          |              |              |              |       |        |        |           |             |
+|         Paging_Linq | .NET 6.0 | 74,073.38 ns |   417.396 ns |   390.433 ns | 1.000 | 9.5215 | 2.3193 |  160352 B |       1.000 |
+|   Paging_IndexedSet | .NET 6.0 |    178.31 ns |     0.899 ns |     0.751 ns | 0.002 | 0.0277 |      - |     464 B |       0.003 |
+|                     |          |              |              |              |       |        |        |           |             |
+|         Paging_Linq | .NET 7.0 | 77,957.27 ns | 1,269.528 ns | 1,187.517 ns | 1.000 | 9.5215 | 2.3193 |  160352 B |       1.000 |
+|   Paging_IndexedSet | .NET 7.0 |    177.73 ns |     1.209 ns |     1.072 ns | 0.002 | 0.0277 |      - |     464 B |       0.003 |
+|                     |          |              |              |              |       |        |        |           |             |
+|          Range_Linq | .NET 6.0 | 21,216.35 ns |   126.899 ns |   112.493 ns |  1.00 |      - |      - |     168 B |        1.00 |
+|    Range_IndexedSet | .NET 6.0 |  2,865.57 ns |     4.970 ns |     4.406 ns |  0.14 | 0.0038 |      - |      72 B |        0.43 |
+|                     |          |              |              |              |       |        |        |           |             |
+|          Range_Linq | .NET 7.0 | 26,593.48 ns |   104.328 ns |    87.118 ns |  1.00 |      - |      - |     160 B |        1.00 |
+|    Range_IndexedSet | .NET 7.0 |  2,676.51 ns |     4.266 ns |     3.562 ns |  0.10 | 0.0038 |      - |      72 B |        0.45 |
 
 > ℹ️ There is no built-in range data structure, hence no comparison. Paging covers sorting scenarios, while min-queries cover MinBy and MaxBy-Queries as well.
 
 ## Prefix-Index
-|                     Method |  Runtime |         Mean |      Error |     StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
-|--------------------------- |--------- |-------------:|-----------:|-----------:|------:|-------:|----------:|------------:|
-|       FuzzyStartsWith_Linq | .NET 6.0 | 48,835.23 ns | 750.969 ns | 702.457 ns |  1.00 | 4.7607 |   80040 B |        1.00 |
-| FuzzyStartsWith_IndexedSet | .NET 6.0 | 13,862.70 ns | 210.747 ns | 197.133 ns |  0.28 | 1.3275 |   22304 B |        0.28 |
-|                            |          |              |            |            |       |        |           |             |
-|       FuzzyStartsWith_Linq | .NET 7.0 | 43,357.99 ns | 516.779 ns | 483.395 ns |  1.00 | 4.7607 |   80040 B |        1.00 |
-| FuzzyStartsWith_IndexedSet | .NET 7.0 | 12,734.14 ns | 161.187 ns | 150.775 ns |  0.29 | 1.2207 |   20608 B |        0.26 |
-|                            |          |              |            |            |       |        |           |             |
-|            StartsWith_Linq | .NET 6.0 |  8,723.26 ns |  60.368 ns |  50.410 ns | 1.000 |      - |      40 B |        1.00 |
-|      StartsWith_IndexedSet | .NET 6.0 |     76.42 ns |   0.237 ns |   0.210 ns | 0.009 |      - |         - |        0.00 |
-|                            |          |              |            |            |       |        |           |             |
-|            StartsWith_Linq | .NET 7.0 |  7,248.18 ns |  54.945 ns |  42.898 ns |  1.00 |      - |      40 B |        1.00 |
-|      StartsWith_IndexedSet | .NET 7.0 |     78.57 ns |   0.181 ns |   0.170 ns |  0.01 |      - |         - |        0.00 |
+|                     Method |  Runtime |        Mean |     Error |    StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
+|--------------------------- |--------- |------------:|----------:|----------:|------:|-------:|----------:|------------:|
+|       FuzzyStartsWith_Linq | .NET 6.0 | 67,594.1 ns | 439.91 ns | 411.49 ns |  1.00 | 5.7373 |   96088 B |       1.000 |
+| FuzzyStartsWith_IndexedSet | .NET 6.0 | 21,357.0 ns |  67.98 ns |  60.26 ns |  0.32 |      - |     240 B |       0.002 |
+|                            |          |             |           |           |       |        |           |             |
+|       FuzzyStartsWith_Linq | .NET 7.0 | 60,252.2 ns | 131.99 ns | 110.22 ns |  1.00 | 5.7373 |   96088 B |       1.000 |
+| FuzzyStartsWith_IndexedSet | .NET 7.0 | 17,309.5 ns |  97.84 ns |  86.73 ns |  0.29 |      - |     240 B |       0.002 |
+|                            |          |             |           |           |       |        |           |             |
+|            StartsWith_Linq | .NET 6.0 |  3,910.7 ns |  11.42 ns |  10.12 ns |  1.00 | 0.0076 |     128 B |        1.00 |
+|      StartsWith_IndexedSet | .NET 6.0 |    635.7 ns |   2.04 ns |   1.91 ns |  0.16 | 0.0086 |     144 B |        1.12 |
+|                            |          |             |           |           |       |        |           |             |
+|            StartsWith_Linq | .NET 7.0 |  2,622.0 ns |  16.95 ns |  15.02 ns |  1.00 | 0.0076 |     128 B |        1.00 |
+|      StartsWith_IndexedSet | .NET 7.0 |    604.3 ns |   2.00 ns |   1.87 ns |  0.23 | 0.0086 |     144 B |        1.12 |
 
 > ℹ️ Fuzzy-Matching of string pairs within the Linq-Benchmark is done with [Fastenshtein](https://github.com/DanHarltey/Fastenshtein)
 
 ## FullText-Index
 
-|                   Method |  Runtime |           Mean |        Error |       StdDev | Ratio |     Gen0 | Allocated | Alloc Ratio |
-|------------------------- |--------- |---------------:|-------------:|-------------:|------:|---------:|----------:|------------:|
-|            Contains_Linq | .NET 6.0 |    40,473.6 ns |    366.10 ns |    342.45 ns | 1.000 |        - |      40 B |        1.00 |
-|      Contains_IndexedSet | .NET 6.0 |       131.8 ns |      0.54 ns |      0.51 ns | 0.003 |   0.0114 |     192 B |        4.80 |
-|                          |          |                |              |              |       |          |           |             |
-|            Contains_Linq | .NET 7.0 |    12,074.5 ns |     85.10 ns |     75.44 ns |  1.00 |        - |      40 B |        1.00 |
-|      Contains_IndexedSet | .NET 7.0 |       136.5 ns |      0.54 ns |      0.51 ns |  0.01 |   0.0114 |     192 B |        4.80 |
-|                          |          |                |              |              |       |          |           |             |
-|       FuzzyContains_Linq | .NET 6.0 | 4,654,014.7 ns | 15,103.29 ns | 14,127.63 ns |  1.00 | 281.2500 | 4831711 B |        1.00 |
-| FuzzyContains_IndexedSet | .NET 6.0 |   139,105.9 ns |    469.74 ns |    439.40 ns |  0.03 |  15.3809 |  260624 B |        0.05 |
-|                          |          |                |              |              |       |          |           |             |
-|       FuzzyContains_Linq | .NET 7.0 | 4,927,249.0 ns |  8,211.41 ns |  7,279.20 ns |  1.00 | 281.2500 | 4831710 B |        1.00 |
-| FuzzyContains_IndexedSet | .NET 7.0 |   122,926.1 ns |    905.08 ns |    802.33 ns |  0.02 |  14.6484 |  247200 B |        0.05 |
+|                   Method |  Runtime |           Mean |         Error |        StdDev | Ratio |     Gen0 | Allocated | Alloc Ratio |
+|------------------------- |--------- |---------------:|--------------:|--------------:|------:|---------:|----------:|------------:|
+|            Contains_Linq | .NET 6.0 |    16,333.1 ns |      26.30 ns |      24.60 ns |  1.00 |        - |     408 B |        1.00 |
+|      Contains_IndexedSet | .NET 6.0 |       479.9 ns |       0.93 ns |       0.82 ns |  0.03 |   0.0238 |     400 B |        0.98 |
+|                          |          |                |               |               |       |          |           |             |
+|            Contains_Linq | .NET 7.0 |     6,599.3 ns |       8.86 ns |       6.92 ns |  1.00 |   0.0229 |     408 B |        1.00 |
+|      Contains_IndexedSet | .NET 7.0 |       467.7 ns |       1.11 ns |       0.99 ns |  0.07 |   0.0238 |     400 B |        0.98 |
+|                          |          |                |               |               |       |          |           |             |
+|       FuzzyContains_Linq | .NET 6.0 | 7,204,157.6 ns |  80,806.42 ns |  71,632.79 ns |  1.00 | 281.2500 | 4831744 B |       1.000 |
+| FuzzyContains_IndexedSet | .NET 6.0 |   182,005.5 ns |     876.51 ns |     819.89 ns |  0.03 |        - |     608 B |       0.000 |
+|                          |          |                |               |               |       |          |           |             |
+|       FuzzyContains_Linq | .NET 7.0 | 7,365,406.9 ns | 143,088.92 ns | 153,103.54 ns |  1.00 | 281.2500 | 4831743 B |       1.000 |
+| FuzzyContains_IndexedSet | .NET 7.0 |   147,192.9 ns |   1,507.18 ns |   1,409.81 ns |  0.02 |        - |     608 B |       0.000 |
 
 > ℹ️ Fuzzy-Matching of string pairs within the Linq-Benchmark is done with [Fastenshtein](https://github.com/DanHarltey/Fastenshtein) and enumerating possible infixes.
 
 ## ConcurrentSet
 
-|                   Method |      Job |  Runtime |         Mean |      Error |     StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
-|------------------------- |--------- |--------- |-------------:|-----------:|-----------:|------:|-------:|----------:|------------:|
-|           FullTextLookup | .NET 6.0 | .NET 6.0 | 10,495.89 ns |  53.539 ns |  50.081 ns |  1.00 | 1.1444 |   19288 B |        1.00 |
-| ConcurrentFullTextLookup | .NET 6.0 | .NET 6.0 | 10,573.92 ns |  61.314 ns |  57.353 ns |  1.01 | 1.1444 |   19360 B |        1.00 |
-|                          |          |          |              |            |            |       |        |           |             |
-|           FullTextLookup | .NET 7.0 | .NET 7.0 | 10,387.22 ns | 112.930 ns | 105.634 ns |  1.00 | 1.0986 |   18520 B |        1.00 |
-| ConcurrentFullTextLookup | .NET 7.0 | .NET 7.0 | 10,791.14 ns |  54.652 ns |  48.448 ns |  1.04 | 1.0986 |   18592 B |        1.00 |
-|                          |          |          |              |            |            |       |        |           |             |
-|           LessThanLookup | .NET 6.0 | .NET 6.0 |     24.40 ns |   0.065 ns |   0.057 ns |  1.00 | 0.0038 |      64 B |        1.00 |
-| ConcurrentLessThanLookup | .NET 6.0 | .NET 6.0 |     53.61 ns |   0.197 ns |   0.184 ns |  2.20 | 0.0057 |      96 B |        1.50 |
-|                          |          |          |              |            |            |       |        |           |             |
-|           LessThanLookup | .NET 7.0 | .NET 7.0 |     21.83 ns |   0.075 ns |   0.070 ns |  1.00 |      - |         - |          NA |
-| ConcurrentLessThanLookup | .NET 7.0 | .NET 7.0 |     48.59 ns |   0.154 ns |   0.128 ns |  2.23 | 0.0019 |      32 B |          NA |
-|                          |          |          |              |            |            |       |        |           |             |
-|             UniqueLookup | .NET 6.0 | .NET 6.0 |     15.32 ns |   0.058 ns |   0.045 ns |  1.00 |      - |         - |          NA |
-|   ConcurrentUniqueLookup | .NET 6.0 | .NET 6.0 |     33.45 ns |   0.173 ns |   0.145 ns |  2.18 |      - |         - |          NA |
-|                          |          |          |              |            |            |       |        |           |             |
-|             UniqueLookup | .NET 7.0 | .NET 7.0 |     15.32 ns |   0.010 ns |   0.008 ns |  1.00 |      - |         - |          NA |
-|   ConcurrentUniqueLookup | .NET 7.0 | .NET 7.0 |     36.11 ns |   0.044 ns |   0.039 ns |  2.36 |      - |         - |          NA |
+|                   Method |  Runtime |         Mean |      Error |     StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|------------------------- |--------- |-------------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
+|           FullTextLookup | .NET 6.0 | 25,362.62 ns |  86.745 ns |  81.141 ns |  1.00 |    0.00 |      - |     424 B |        1.00 |
+| ConcurrentFullTextLookup | .NET 6.0 | 25,073.88 ns | 103.270 ns |  91.546 ns |  0.99 |    0.00 |      - |     464 B |        1.09 |
+|                          |          |              |            |            |       |         |        |           |             |
+|           FullTextLookup | .NET 7.0 | 19,415.45 ns | 134.922 ns | 119.604 ns |  1.00 |    0.00 |      - |     424 B |        1.00 |
+| ConcurrentFullTextLookup | .NET 7.0 | 19,553.58 ns | 135.104 ns | 126.376 ns |  1.01 |    0.01 |      - |     464 B |        1.09 |
+|                          |          |              |            |            |       |         |        |           |             |
+|           LessThanLookup | .NET 6.0 |     25.35 ns |   0.119 ns |   0.112 ns |  1.00 |    0.00 | 0.0038 |      64 B |        1.00 |
+| ConcurrentLessThanLookup | .NET 6.0 |     52.05 ns |   0.118 ns |   0.110 ns |  2.05 |    0.01 | 0.0038 |      64 B |        1.00 |
+|                          |          |              |            |            |       |         |        |           |             |
+|           LessThanLookup | .NET 7.0 |     22.00 ns |   0.035 ns |   0.033 ns |  1.00 |    0.00 |      - |         - |          NA |
+| ConcurrentLessThanLookup | .NET 7.0 |     49.20 ns |   0.319 ns |   0.298 ns |  2.24 |    0.02 |      - |         - |          NA |
+|                          |          |              |            |            |       |         |        |           |             |
+|             UniqueLookup | .NET 6.0 |     15.75 ns |   0.061 ns |   0.057 ns |  1.00 |    0.00 |      - |         - |          NA |
+|   ConcurrentUniqueLookup | .NET 6.0 |     34.87 ns |   0.716 ns |   0.906 ns |  2.24 |    0.06 |      - |         - |          NA |
+|                          |          |              |            |            |       |         |        |           |             |
+|             UniqueLookup | .NET 7.0 |     15.43 ns |   0.014 ns |   0.012 ns |  1.00 |    0.00 |      - |         - |          NA |
+|   ConcurrentUniqueLookup | .NET 7.0 |     34.09 ns |   0.068 ns |   0.060 ns |  2.21 |    0.00 |      - |         - |          NA |
 
 > ℹ️ For more complex scenarios, the synchronization cost is negligble. For simple queries, it is not.
 The difference in allocated memory is due to materialization of results in the concurrent case.


### PR DESCRIPTION
If the first character was changed for a fuzzy search, it did not return all results correctly. Prefix & FullText Indices were potentially affected. While the fix requires more branches of the trie to be explored, reduced allocations bring the performance back on par.