### PR TITLE
[Fix] Fixes incorrect warnings on ConcurrentSet.Update

### DIFF
--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/SimpleAnalyzerTests.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/SimpleAnalyzerTests.cs
@@ -64,4 +64,29 @@ public class SimpleAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code, name);
     }
+
+    [TestMethod]
+    public async Task No_diagnostic_reported_for_concurrent_set_update()
+    {
+        string code = $$"""
+         using Akade.IndexedSet;
+         using Akade.IndexedSet.Concurrency;
+         
+
+         ConcurrentIndexedSet<int> test = new[]{5,10,20}.ToIndexedSet()
+                                                        .WithIndex(x => x)
+                                                        .BuildConcurrent();
+
+         test.Update(set => { 
+            set.Add(1);
+            set.Add(2);
+         });
+         test.Update((set, state) => {
+            set.Add(3);
+            set.Add(4);
+         }, 8);
+         """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/Analyzers/Akade.IndexedSet.Analyzers/IndexNamingRulesAnalyzer.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers/IndexNamingRulesAnalyzer.cs
@@ -80,7 +80,8 @@ public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
                 && namedType.IsGenericType
                 && _relevantTypes.Contains(namedType.OriginalDefinition))
             {
-                if (node.ArgumentList.Arguments.FirstOrDefault()?.Expression is LambdaExpressionSyntax lambda)
+                if (node.ArgumentList.Arguments.FirstOrDefault()?.Expression is LambdaExpressionSyntax lambda
+                    && !IsExcludedMethod(memberAccess.Name.Identifier))
                 {
                     CheckParameterName(context, lambda);
                     CheckForParenthesized(context, lambda);
@@ -88,6 +89,11 @@ public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
+    }
+
+    private bool IsExcludedMethod(SyntaxToken identifier)
+    {
+        return identifier.ValueText is "Update";
     }
 
     private void CheckForBlockBodiedLambda(SyntaxNodeAnalysisContext context, LambdaExpressionSyntax lambda)


### PR DESCRIPTION
Analyzer incorrectly applied index naming rules on ConcurrentSet.Update, whose first parameter is a lambda but not one for an index