### PR TITLE
ConcurrentSet.Read

### DIFF
--- a/Akade.IndexedSet/PublicAPI.Unshipped.txt
+++ b/Akade.IndexedSet/PublicAPI.Unshipped.txt
@@ -1,9 +1,12 @@
 ﻿#nullable enable
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Dispose() -> void
+Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Read(System.Func<Akade.IndexedSet.IndexedSet<TElement>!, System.Collections.Generic.IEnumerable<TElement>!>! readFunc) -> System.Collections.Generic.IEnumerable<TElement>!
+Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Read<TState>(TState state, System.Func<Akade.IndexedSet.IndexedSet<TElement>!, TState, System.Collections.Generic.IEnumerable<TElement>!>! readFunc) -> System.Collections.Generic.IEnumerable<TElement>!
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update(TElement element, System.Action<TElement>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(TElement element, TState state, System.Action<TElement, TState>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update(TElement element, System.Func<TElement, TElement>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(TElement element, TState state, System.Func<TElement, TState, TElement>! updateFunc) -> bool
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Contains(TElement element) -> bool
+Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TElement>.Update<TState>(TState state, System.Action<Akade.IndexedSet.IndexedSet<TElement>!, TState>! updateFunc) -> void
 Akade.IndexedSet.Concurrency.ConcurrentIndexedSet<TPrimaryKey, TElement>.TryGetSingle(TPrimaryKey key, out TElement? result) -> bool
 Akade.IndexedSet.IndexedSet<TPrimaryKey, TElement>.TryGetSingle(TPrimaryKey key, out TElement? result) -> bool

--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/Akade.IndexedSet.Analyzers.Test.csproj
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/Akade.IndexedSet.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/ReadMethodDoesNotContainWriteMethodAccess.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/ReadMethodDoesNotContainWriteMethodAccess.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using VerifyCS = Akade.IndexedSet.Analyzers.Test.CSharpAnalyzerVerifier<Akade.IndexedSet.Analyzers.ConcurrentSetUsageAnalyzers>;
+
+namespace Akade.IndexedSet.Analyzers.Test;
+
+[TestClass]
+public class ReadMethodDoesNotContainWriteMethodAccess
+{
+    private const string _initialization = $$"""
+     using Akade.IndexedSet;
+     using Akade.IndexedSet.Concurrency;
+     using System.Linq;
+
+     ConcurrentIndexedSet<int> test = new[]{5,10,20}.ToIndexedSet()
+                                                    .WithIndex(x => x)
+                                                    .BuildConcurrent();
+     """;
+
+
+    [TestMethod]
+    public async Task Calling_add_within_read_fails()
+    {
+        string code = $$"""
+         {{_initialization}}
+         test.Read(set => { 
+            {|#0:set.Add|}(1);
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        DiagnosticResult name = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId)
+                                .WithLocation(0);
+        await VerifyCS.VerifyAnalyzerAsync(code, name);
+    }
+
+    [TestMethod]
+    public async Task Calling_AddRange_within_read_fails()
+    {
+        string code = $$"""
+         {{_initialization}}
+         test.Read(set => { 
+            {|#0:set.AddRange|}(new[]{ 1, 2 });
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        DiagnosticResult name = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId)
+                                .WithLocation(0);
+        await VerifyCS.VerifyAnalyzerAsync(code, name);
+    }
+
+    [TestMethod]
+    public async Task Calling_Remove_within_read_fails()
+    {
+        string code = $$"""
+         {{_initialization}}
+         test.Read(set => { 
+            {|#0:set.Remove|}(5);
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        DiagnosticResult name = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId)
+                                .WithLocation(0);
+        await VerifyCS.VerifyAnalyzerAsync(code, name);
+    }
+
+    [TestMethod]
+    public async Task Calling_Clear_within_read_fails()
+    {
+        string code = $$"""
+         {{_initialization}}
+         test.Read(set => { 
+            {|#0:set.Clear|}();
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        DiagnosticResult name = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId)
+                                .WithLocation(0);
+        await VerifyCS.VerifyAnalyzerAsync(code, name);
+    }
+
+    [TestMethod]
+    public async Task Calling_Update_within_read_fails()
+    {
+        string code = $$"""
+         {{_initialization}}
+         test.Read(set => { 
+            {|#0:set.Update|}(5, element => {});
+            {|#1:set.Update|}(5, 3, (element, state) => {});
+            {|#2:set.Update|}(5, element => element * 3);
+            {|#3:set.Update|}(5, 3, (element, state) => element * state);
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        DiagnosticResult overload1 = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId).WithLocation(0);
+        DiagnosticResult overload2 = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId).WithLocation(1);
+        DiagnosticResult overload3 = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId).WithLocation(2);
+        DiagnosticResult overload4 = VerifyCS.Diagnostic(ConcurrentSetUsageAnalyzers.DoNotPerformWritesWithinReadLockRuleId).WithLocation(3);
+
+        await VerifyCS.VerifyAnalyzerAsync(code, overload1, overload2, overload3, overload4);
+
+    }
+}

--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/SimpleAnalyzerTests.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/SimpleAnalyzerTests.cs
@@ -89,4 +89,25 @@ public class SimpleAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task No_diagnostic_reported_for_concurrent_set_read()
+    {
+        string code = $$"""
+         using Akade.IndexedSet;
+         using Akade.IndexedSet.Concurrency;
+         using System.Linq;
+     
+
+         ConcurrentIndexedSet<int> test = new[]{5,10,20}.ToIndexedSet()
+                                                        .WithIndex(x => x)
+                                                        .BuildConcurrent();
+
+         test.Read(set => { 
+            return Enumerable.Empty<int>();
+         });
+         """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier+Test.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier+Test.cs
@@ -1,6 +1,5 @@
 ﻿using Akade.IndexedSet.Analyzers.Test.Verifiers;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -13,11 +12,10 @@ using System.IO;
 
 namespace Akade.IndexedSet.Analyzers.Test;
 
-public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
-    where TCodeFix : CodeFixProvider, new()
 {
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+    public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
     {
         public Test()
         {
@@ -31,7 +29,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
             SolutionTransforms.Add((solution, projectId) =>
             {
                 Project project = solution.GetProject(projectId);
-                
+
                 var parseOptions = (CSharpParseOptions)project.ParseOptions;
                 parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.Latest);
 

--- a/Analyzers/Akade.IndexedSet.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akade.IndexedSet.Analyzers.Test;
+
+public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+    public static DiagnosticResult Diagnostic()
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
+    }
+
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
+    }
+
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+    public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+    {
+        return CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+    }
+
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+    public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+}

--- a/Analyzers/Akade.IndexedSet.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Analyzers/Akade.IndexedSet.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,1 +1,5 @@
-﻿
+﻿### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AkadeIndexedSet0004 | Akade.IndexedSet.ConcurrencyRules | Error | ConcurrentSetUsageAnalyzers, [Documentation](https://github.com/akade/Akade.IndexedSet/tree/main/Akade.IndexedSet.Analyzers/Readme.md#AkadeIndexedSet0004)

--- a/Analyzers/Akade.IndexedSet.Analyzers/ConcurrentSetUsageAnalyzers.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers/ConcurrentSetUsageAnalyzers.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Akade.IndexedSet.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "Does not work with Microsoft.CodeAnalysis.Analyzers")]
+public sealed class ConcurrentSetUsageAnalyzers : DiagnosticAnalyzer
+{
+    public const string RulesCategory = "Akade.IndexedSet.ConcurrencyRules";
+    public const string HelpLinkBase = "https://github.com/akade/Akade.IndexedSet/tree/main/Akade.IndexedSet.Analyzers/Readme.md#";
+
+    public const string DoNotPerformWritesWithinReadLockRuleId = "AkadeIndexedSet0004";
+
+    private static readonly DiagnosticDescriptor _doNotPerformWritesWithinReadLock = new DiagnosticDescriptor(
+        id: DoNotPerformWritesWithinReadLockRuleId,
+        title: "Do not perform writes within a read-lock",
+        messageFormat: "Do not perform writes within a read-lock",
+        category: RulesCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Do not perform writes within a read-lock as it may result in incorrect reads, or even corrupted state.",
+        helpLinkUri: HelpLinkBase + DoNotPerformWritesWithinReadLockRuleId);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(_doNotPerformWritesWithinReadLock);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.InvocationExpression);
+    }
+
+    private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+    {
+        var node = (InvocationExpressionSyntax)context.Node;
+
+        var concurrentSet = new INamedTypeSymbol?[]
+        {
+             context.Compilation.GetTypeByMetadataName("Akade.IndexedSet.Concurrency.ConcurrentIndexedSet`1"),
+             context.Compilation.GetTypeByMetadataName("Akade.IndexedSet.Concurrency.ConcurrentIndexedSet`2"),
+        }.OfType<INamedTypeSymbol>()
+         .ToImmutableHashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        var indexedSet = new INamedTypeSymbol?[]
+        {
+             context.Compilation.GetTypeByMetadataName("Akade.IndexedSet.IndexedSet`1"),
+             context.Compilation.GetTypeByMetadataName("Akade.IndexedSet.IndexedSet`2"),
+        }.OfType<INamedTypeSymbol>()
+         .ToImmutableHashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        if (node.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            ITypeSymbol? targetExpressionType = context.SemanticModel.GetTypeInfo(memberAccess.Expression).Type;
+            if (targetExpressionType is INamedTypeSymbol namedType
+                && namedType.IsGenericType
+                && indexedSet.Contains(namedType.OriginalDefinition))
+            {
+                if (IsWriteMethod(memberAccess.Name.Identifier.ValueText))
+                {
+                    bool isWithinRead = node.Ancestors()
+                                            .OfType<InvocationExpressionSyntax>()
+                                            .Where(invocation => invocation.Expression is MemberAccessExpressionSyntax)
+                                            .Select(invocation => (MemberAccessExpressionSyntax)invocation.Expression)
+                                            .Where(m => context.SemanticModel.GetTypeInfo(m.Expression).Type is INamedTypeSymbol namedType
+                                                        && namedType.IsGenericType
+                                                        && concurrentSet.Contains(namedType.OriginalDefinition))
+                                            .Where(m => m.Name.Identifier.ValueText == "Read").Any();
+
+                    if(isWithinRead)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(_doNotPerformWritesWithinReadLock, memberAccess.GetLocation()));
+                    }
+                }
+            }
+        }
+    }
+
+    private bool IsWriteMethod(string valueText)
+    {
+        return valueText
+            is "Add"
+            or "AddRange"
+            or "Remove"
+            or "Clear"
+            or "Update";
+
+
+    }
+}

--- a/Analyzers/Akade.IndexedSet.Analyzers/IndexNamingRulesAnalyzer.cs
+++ b/Analyzers/Akade.IndexedSet.Analyzers/IndexNamingRulesAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Akade.IndexedSet.Analyzers;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "Does not work with Microsoft.CodeAnalysis.Analyzers")]
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
+public sealed class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
 {
     public const string RulesCategory = "Akade.IndexedSet.IndexNaming";
     public const string HelpLinkBase = "https://github.com/akade/Akade.IndexedSet/tree/main/Akade.IndexedSet.Analyzers/Readme.md#";
@@ -48,8 +48,7 @@ public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
         description: "Use the convention of expression bodied lambdas for simple indices or static methods for more complex indices to consistently name indices.",
         helpLinkUri: HelpLinkBase + DoNotUseBlockBodiedLambdaRuleId);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(_useXInLambdaDescriptor, _doNotUseParenthesesDescriptor, _doNotUseBlockBodiedLambdaDescriptor);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(_useXInLambdaDescriptor, _doNotUseParenthesesDescriptor, _doNotUseBlockBodiedLambdaDescriptor);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -80,8 +79,8 @@ public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
                 && namedType.IsGenericType
                 && _relevantTypes.Contains(namedType.OriginalDefinition))
             {
-                if (node.ArgumentList.Arguments.FirstOrDefault()?.Expression is LambdaExpressionSyntax lambda
-                    && !IsExcludedMethod(memberAccess.Name.Identifier))
+                if (!IsExcludedMethod(memberAccess.Name.Identifier)
+                    && node.ArgumentList.Arguments.FirstOrDefault()?.Expression is LambdaExpressionSyntax lambda)
                 {
                     CheckParameterName(context, lambda);
                     CheckForParenthesized(context, lambda);
@@ -93,7 +92,7 @@ public class IndexNamingRulesAnalyzer : DiagnosticAnalyzer
 
     private bool IsExcludedMethod(SyntaxToken identifier)
     {
-        return identifier.ValueText is "Update";
+        return identifier.ValueText is "Update" or "Read";
     }
 
     private void CheckForBlockBodiedLambda(SyntaxNodeAnalysisContext context, LambdaExpressionSyntax lambda)

--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ Potential features (not ordered):
 - [x] Refactoring to allow a primarykey-less set: this was an artifical restriction that is not necessary
 - [x] Benchmarks
 - [x] Simplification of string indices, i.e. Span/String based overloads to avoid `AsMemory()`...
+- [x] Analyzers to help with best practices
 - [ ] Tree-based range index for better insertion performance
-- [ ] Analyzers to help with best practices
 - [ ] Aggregates (i.e. sum or average: interface based on state & add/removal state update functions)
 - [ ] Custom (equality) comparators for indices
 


### PR DESCRIPTION
ConcurrentSet.Read: A method that allows access to the underlying set while being protected by the read lock. Analyzer to prevent calling any write method within Read.